### PR TITLE
Project versions

### DIFF
--- a/services/src/contexts/postgres.rs
+++ b/services/src/contexts/postgres.rs
@@ -130,9 +130,8 @@ where
                             latest boolean
                         );
 
-                        -- TODO: unique constraint poject_id, lates = true?
-                        -- TODO: index on latest
-
+                        CREATE INDEX project_version_latest_idx 
+                        ON project_versions (project_id, latest DESC, time DESC, author_user_id DESC);
 
                         CREATE TYPE layer_type AS ENUM ('raster', 'vector'); -- TODO: distinguish points/lines/polygons
 
@@ -160,8 +159,6 @@ where
                             id UUID PRIMARY KEY,
                             workflow json NOT NULL
                         );
-
-                        -- TODO: indexes
                         ",
                     )
                     .await?;

--- a/services/src/projects/hashmap_projectdb.rs
+++ b/services/src/projects/hashmap_projectdb.rs
@@ -130,11 +130,6 @@ impl ProjectDB for HashMapProjectDB {
 
         let project_update = project.update_project(update, user);
 
-        ensure!(
-            project_update.version > project.version,
-            error::ProjectUpdateFailed
-        );
-
         project_versions.push(project_update);
 
         Ok(())

--- a/services/src/projects/postgres_projectdb.rs
+++ b/services/src/projects/postgres_projectdb.rs
@@ -527,7 +527,10 @@ where
         let conn = self.conn_pool.get().await?;
         let stmt = conn
             .prepare(
-                "SELECT id, time, author_user_id FROM project_versions WHERE project_id = $1 ORDER BY time DESC",
+                "
+                SELECT id, time, author_user_id
+                FROM project_versions WHERE project_id = $1 
+                ORDER BY latest DESC, time DESC, author_user_id DESC",
             )
             .await?;
 

--- a/services/src/projects/project.rs
+++ b/services/src/projects/project.rs
@@ -13,7 +13,6 @@ use geoengine_datatypes::{operations::image::Colorizer, primitives::TimeInstance
 use postgres_types::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
 use snafu::{ensure, ResultExt};
-use std::cmp::Ordering;
 use uuid::Uuid;
 
 identifier!(ProjectId);
@@ -331,12 +330,6 @@ impl ProjectVersion {
             changed: chrono::offset::Utc::now(),
             author: user,
         }
-    }
-}
-
-impl PartialOrd for ProjectVersion {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.changed.partial_cmp(&other.changed)
     }
 }
 


### PR DESCRIPTION
I removed the check that versions must have a greater timestamp than the previous one because it causes tests to fail on my maschine because creation and update seem to happen at the same system time. The alternative would be to `sleep` shortly. However, as projects can be shared it's always possible two modifications happen at the same timestamp and that's ok as we shouldn't aim to solve phantom update problem here, as long as 
- the history is not lost
- there is only one true latest version of a project

this is both guaranteed for the postgres version

Another item to address: The `ProjectVersion` struct gets the local current time on `new` but the postgres item doesn't use this value but rather states `CURRENT_TIMESTAMP` and uses the database`s clock.
See:  https://github.com/geo-engine/geoengine/blob/versioning/services/src/projects/project.rs#L330 and https://github.com/geo-engine/geoengine/blob/versioning/services/src/projects/postgres_projectdb.rs#L430 . Shouldn't be a problem in practice but is ugly nonetheless. thoughts?

