### PR TITLE
fix new clippy warnings

### DIFF
--- a/datatypes/src/collections/multi_point_collection.rs
+++ b/datatypes/src/collections/multi_point_collection.rs
@@ -641,6 +641,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::eq_op)]
     fn nan_equals() {
         let collection = {
             let mut builder = MultiPointCollection::builder();
@@ -671,6 +672,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::eq_op)]
     fn null_equals() {
         let collection = {
             let mut builder = MultiPointCollection::builder();

--- a/datatypes/src/operations/image/colorizer.rs
+++ b/datatypes/src/operations/image/colorizer.rs
@@ -461,7 +461,7 @@ impl RgbaColor {
     /// ```
     #[allow(unstable_name_collisions)]
     pub fn factor_add(self, other: Self, factor: f64) -> Self {
-        debug_assert!(factor >= 0. && factor <= 1.0);
+        debug_assert!((0.0..=1.0).contains(&factor));
 
         let [r, g, b, a] = self.0;
         let [r2, g2, b2, a2] = other.0;

--- a/datatypes/src/plots/histogram.rs
+++ b/datatypes/src/plots/histogram.rs
@@ -1,6 +1,5 @@
 use std::cmp;
 use std::collections::HashMap;
-use std::iter::FromIterator;
 
 use float_cmp::*;
 use ndarray::{stack, Array, Array1, Axis};
@@ -206,7 +205,7 @@ impl Plot for Histogram {
         &self,
         allow_interactions: bool,
     ) -> Result<PlotData<Self::PlotDataMetadataType>> {
-        let bucket_counts = Array1::<f64>::from_iter(self.counts.iter().map(|&v| v as f64));
+        let bucket_counts: Array1<f64> = self.counts.iter().map(|&v| v as f64).collect();
 
         let step = (self.max - self.min) / (self.counts.len() as f64);
 


### PR DESCRIPTION
as we always use the most recent nightly version of clippy, new PRs might fail with errors that have nothing to do with the branch but rather the master that now fails the CI. Maybe we could fix the clippy version to avoid this.