### PR TITLE
Use `rust-toolchain` file to fix Rust version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-20.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v1
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with: # uses rust-toolchain file
-          profile: minimal
-          override: true
       - name: Install OpenCL
         run: |
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,8 @@ jobs:
         uses: actions/checkout@v1
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
-        with:
+        with: # uses rust-toolchain file
           profile: minimal
-          toolchain: nightly-2021-01-03
-          components: clippy, rustfmt
           override: true
       - name: Install OpenCL
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-18.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/fix-nightly.yml
+++ b/.github/workflows/fix-nightly.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set New Rust Nightly Version
         run: |
-          sed -i -r "s:(toolchain\: nightly).+:\1-`date --date=yesterday +%Y-%m-%d`:g" .github/workflows/ci.yml
+          sed -i -r "s:(channel = \"nightly).+:\1-`date --date=yesterday +%Y-%m-%d`\":g" rust-toolchain
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2021-01-03"
-components = ["rustfmt", "rust-src", "clippy"]
+components = ["cargo", "rustfmt", "rust-src", "clippy"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2021-01-03"
+components = ["rustfmt", "rust-src", "clippy"]


### PR DESCRIPTION
Currently, we fix the Rust version in our CI only. Now, we can fix this for our workspace. This means, when you execute `cargo`, `rustup` will automatically install the correct toolchain version for you. 