### PR TITLE
unbreak non postgres build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,12 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-targets --all-features -- -D warnings
-      - name: Build
+      - name: Build (no features)
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose
+      - name: Build (all features)
         uses: actions-rs/cargo@v1
         with:
           command: build

--- a/datatypes/src/spatial_reference.rs
+++ b/datatypes/src/spatial_reference.rs
@@ -6,7 +6,8 @@ use postgres_types::{FromSql, IsNull, ToSql, Type};
 use serde::de::Visitor;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "postgres")]
-use snafu::{Error, ResultExt};
+use snafu::Error;
+use snafu::ResultExt;
 use std::fmt::Formatter;
 use std::str::FromStr;
 


### PR DESCRIPTION
build without postgres feature failed because ResultExt is required for .context() in `impl FromStr for SpatialReference {`
