### PR TITLE
Global tiling spec

### DIFF
--- a/Settings-default.toml
+++ b/Settings-default.toml
@@ -11,3 +11,9 @@ config_string = "postgresql://geoengine:geoengine@localhost:5432"
 
 [operators.gdal_source]
 raster_data_root_path = "operators/test-data/raster"
+
+[raster.tiling_specification]
+    origin_coordinate_x = 0.0
+    origin_coordinate_y = 0.0
+    tile_shape_pixels_x = 600
+    tile_shape_pixels_y = 600

--- a/Settings-test.toml
+++ b/Settings-test.toml
@@ -3,3 +3,9 @@ config_string = "postgresql://geoengine:geoengine@localhost:5432"
 
 [operators.gdal_source]
 raster_data_root_path = "../operators/test-data/raster" # relative to sub crate directory for tests
+
+[raster.tiling_specification]
+    origin_coordinate_x = 0.0
+    origin_coordinate_y = 0.0
+    tile_shape_pixels_x = 600
+    tile_shape_pixels_y = 600

--- a/datatypes/src/raster/geo_transform.rs
+++ b/datatypes/src/raster/geo_transform.rs
@@ -1,7 +1,7 @@
-use crate::primitives::Coordinate2D;
+use crate::primitives::{BoundingBox2D, Coordinate2D};
 use serde::{Deserialize, Serialize};
 
-use super::{GridIdx, GridIdx2D};
+use super::{GridBoundingBox2D, GridIdx, GridIdx2D};
 
 /// This is a typedef for the `GDAL GeoTransform`. It represents an affine transformation matrix.
 pub type GdalGeoTransform = [f64; 6];
@@ -92,6 +92,13 @@ impl GeoTransform {
         let grid_x_index = ((coord.x - self.origin_coordinate.x) / self.x_pixel_size) as isize;
         let grid_y_index = ((coord.y - self.origin_coordinate.y) / self.y_pixel_size) as isize;
         [grid_y_index, grid_x_index].into()
+    }
+
+    /// Transform a BoundingBox2D into a GridBoundingBox
+    pub fn pixel_box(&self, bounding_box: BoundingBox2D) -> GridBoundingBox2D {
+        let start = self.coordinate_to_grid_idx_2d(bounding_box.upper_left());
+        let end = self.coordinate_to_grid_idx_2d(bounding_box.lower_right());
+        GridBoundingBox2D::new_unchecked(start, end)
     }
 }
 

--- a/datatypes/src/raster/geo_transform.rs
+++ b/datatypes/src/raster/geo_transform.rs
@@ -94,7 +94,7 @@ impl GeoTransform {
         [grid_y_index, grid_x_index].into()
     }
 
-    /// Transform a BoundingBox2D into a GridBoundingBox
+    /// Transform a `BoundingBox2D` into a `GridBoundingBox`
     pub fn pixel_box(&self, bounding_box: BoundingBox2D) -> GridBoundingBox2D {
         let start = self.coordinate_to_grid_idx_2d(bounding_box.upper_left());
         let end = self.coordinate_to_grid_idx_2d(bounding_box.lower_right());

--- a/datatypes/src/raster/mod.rs
+++ b/datatypes/src/raster/mod.rs
@@ -10,6 +10,7 @@ mod macros_raster;
 mod macros_raster_tile;
 mod operations;
 mod raster_tile;
+mod tiling;
 mod typed_raster_conversion;
 mod typed_raster_tile;
 
@@ -31,7 +32,8 @@ pub use self::typed_raster_tile::{TypedRasterTile2D, TypedRasterTile3D};
 use super::primitives::{SpatialBounded, TemporalBounded};
 pub use grid::{Grid, Grid1D, Grid2D, Grid3D, GridShape, GridShape1D, GridShape2D, GridShape3D};
 pub use grid_bounds::{GridBoundingBox, GridBoundingBox1D, GridBoundingBox2D, GridBoundingBox3D};
-pub use raster_tile::{RasterTile, RasterTile2D, RasterTile3D, TileInformation};
+pub use raster_tile::{RasterTile, RasterTile2D, RasterTile3D};
+pub use tiling::{TileInformation, TilingStrategy};
 
 pub trait Raster<D, T: Pixel, C>: SpatialBounded + TemporalBounded {
     /// returns the grid dimension object of type D: `GridDimension`

--- a/datatypes/src/raster/mod.rs
+++ b/datatypes/src/raster/mod.rs
@@ -33,7 +33,7 @@ use super::primitives::{SpatialBounded, TemporalBounded};
 pub use grid::{Grid, Grid1D, Grid2D, Grid3D, GridShape, GridShape1D, GridShape2D, GridShape3D};
 pub use grid_bounds::{GridBoundingBox, GridBoundingBox1D, GridBoundingBox2D, GridBoundingBox3D};
 pub use raster_tile::{RasterTile, RasterTile2D, RasterTile3D};
-pub use tiling::{TileInformation, TilingStrategy};
+pub use tiling::{TileInformation, TilingSpecification, TilingStrategy};
 
 pub trait Raster<D, T: Pixel, C>: SpatialBounded + TemporalBounded {
     /// returns the grid dimension object of type D: `GridDimension`

--- a/datatypes/src/raster/raster_tile.rs
+++ b/datatypes/src/raster/raster_tile.rs
@@ -222,7 +222,7 @@ mod tests {
             GridShape2D::from([100, 100]),
             GeoTransform::default(),
         );
-        assert_eq!(ti.local_upper_left_idx(), GridIdx([0, 0]));
+        assert_eq!(ti.local_upper_left_pixel_idx(), GridIdx([0, 0]));
     }
 
     #[test]
@@ -232,7 +232,7 @@ mod tests {
             GridShape2D::from([100, 100]),
             GeoTransform::default(),
         );
-        assert_eq!(ti.local_lower_left_idx(), GridIdx([99, 0]));
+        assert_eq!(ti.local_lower_left_pixel_idx(), GridIdx([99, 0]));
     }
 
     #[test]
@@ -242,7 +242,7 @@ mod tests {
             GridShape2D::from([100, 100]),
             GeoTransform::default(),
         );
-        assert_eq!(ti.local_upper_right_idx(), GridIdx([0, 99]));
+        assert_eq!(ti.local_upper_right_pixel_idx(), GridIdx([0, 99]));
     }
 
     #[test]
@@ -252,7 +252,7 @@ mod tests {
             GridShape2D::from([100, 100]),
             GeoTransform::default(),
         );
-        assert_eq!(ti.local_lower_right_idx(), GridIdx([99, 99]));
+        assert_eq!(ti.local_lower_right_pixel_idx(), GridIdx([99, 99]));
     }
 
     #[test]
@@ -262,7 +262,7 @@ mod tests {
             GridShape2D::from([100, 100]),
             GeoTransform::default(),
         );
-        assert_eq!(ti.global_upper_left_idx(), GridIdx([0, 0]));
+        assert_eq!(ti.global_upper_left_pixel_idx(), GridIdx([0, 0]));
     }
 
     #[test]
@@ -272,7 +272,7 @@ mod tests {
             GridShape2D::from([100, 1000]),
             GeoTransform::default(),
         );
-        assert_eq!(ti.global_upper_left_idx(), GridIdx([-200, 3000]));
+        assert_eq!(ti.global_upper_left_pixel_idx(), GridIdx([-200, 3000]));
     }
 
     #[test]
@@ -282,7 +282,7 @@ mod tests {
             GridShape2D::from([100, 100]),
             GeoTransform::default(),
         );
-        assert_eq!(ti.global_upper_right_idx(), GridIdx([0, 99]));
+        assert_eq!(ti.global_upper_right_pixel_idx(), GridIdx([0, 99]));
     }
 
     #[test]
@@ -292,7 +292,7 @@ mod tests {
             GridShape2D::from([100, 1000]),
             GeoTransform::default(),
         );
-        assert_eq!(ti.global_upper_right_idx(), GridIdx([-200, 3999]));
+        assert_eq!(ti.global_upper_right_pixel_idx(), GridIdx([-200, 3999]));
     }
 
     #[test]
@@ -302,7 +302,7 @@ mod tests {
             GridShape2D::from([100, 100]),
             GeoTransform::default(),
         );
-        assert_eq!(ti.global_lower_right_idx(), GridIdx([99, 99]));
+        assert_eq!(ti.global_lower_right_pixel_idx(), GridIdx([99, 99]));
     }
 
     #[test]
@@ -312,7 +312,7 @@ mod tests {
             GridShape2D::from([100, 1000]),
             GeoTransform::default(),
         );
-        assert_eq!(ti.global_lower_right_idx(), GridIdx([-101, 3999]));
+        assert_eq!(ti.global_lower_right_pixel_idx(), GridIdx([-101, 3999]));
     }
 
     #[test]
@@ -322,7 +322,7 @@ mod tests {
             GridShape2D::from([100, 100]),
             GeoTransform::default(),
         );
-        assert_eq!(ti.global_lower_left_idx(), GridIdx([99, 0]));
+        assert_eq!(ti.global_lower_left_pixel_idx(), GridIdx([99, 0]));
     }
 
     #[test]
@@ -332,7 +332,7 @@ mod tests {
             GridShape2D::from([100, 1000]),
             GeoTransform::default(),
         );
-        assert_eq!(ti.global_lower_left_idx(), GridIdx([-101, 3000]));
+        assert_eq!(ti.global_lower_left_pixel_idx(), GridIdx([-101, 3000]));
     }
 
     #[test]
@@ -342,7 +342,10 @@ mod tests {
             GridShape2D::from([100, 100]),
             GeoTransform::default(),
         );
-        assert_eq!(ti.local_to_global_idx(GridIdx([25, 75])), GridIdx([25, 75]));
+        assert_eq!(
+            ti.local_to_global_pixel_idx(GridIdx([25, 75])),
+            GridIdx([25, 75])
+        );
     }
 
     #[test]
@@ -353,7 +356,7 @@ mod tests {
             GeoTransform::default(),
         );
         assert_eq!(
-            ti.local_to_global_idx(GridIdx([25, 75])),
+            ti.local_to_global_pixel_idx(GridIdx([25, 75])),
             GridIdx([-175, 3075])
         );
     }

--- a/datatypes/src/raster/raster_tile.rs
+++ b/datatypes/src/raster/raster_tile.rs
@@ -1,6 +1,6 @@
 use super::{
     GeoTransform, Grid, GridBounds, GridIdx, GridIdx2D, GridIndexAccess, GridIndexAccessMut,
-    GridShape2D, GridShape3D, GridSize, GridSpaceToLinearSpace, Raster,
+    GridShape2D, GridShape3D, GridSize, GridSpaceToLinearSpace, Raster, TileInformation,
 };
 use crate::primitives::{BoundingBox2D, SpatialBounded, TemporalBounded, TimeInterval};
 use crate::raster::data_type::FromPrimitive;
@@ -112,100 +112,6 @@ where
             .into(),
             self.global_geo_transform,
         )
-    }
-}
-
-/// The `TileInformation` is used to represent the spatial position of each tile
-#[derive(PartialEq, Debug, Copy, Clone, Serialize, Deserialize)]
-pub struct TileInformation {
-    pub tile_size_in_pixels: GridShape2D,
-    pub global_tile_position: GridIdx2D,
-    pub global_geo_transform: GeoTransform,
-}
-
-impl TileInformation {
-    pub fn new(
-        global_tile_position: GridIdx2D,
-        tile_size_in_pixels: GridShape2D,
-        global_geo_transform: GeoTransform,
-    ) -> Self {
-        Self {
-            global_tile_position,
-            tile_size_in_pixels,
-            global_geo_transform,
-        }
-    }
-
-    #[allow(clippy::unused_self)]
-    pub fn local_upper_left_idx(&self) -> GridIdx2D {
-        [0, 0].into()
-    }
-
-    pub fn local_lower_left_idx(&self) -> GridIdx2D {
-        [self.tile_size_in_pixels.axis_size_y() as isize - 1, 0].into()
-    }
-
-    pub fn local_upper_right_idx(&self) -> GridIdx2D {
-        [0, self.tile_size_in_pixels.axis_size_x() as isize - 1].into()
-    }
-
-    pub fn local_lower_right_idx(&self) -> GridIdx2D {
-        let GridIdx([y, _]) = self.local_lower_left_idx();
-        let GridIdx([_, x]) = self.local_upper_right_idx();
-        [y, x].into()
-    }
-
-    pub fn global_tile_position(&self) -> GridIdx2D {
-        self.global_tile_position
-    }
-
-    pub fn global_upper_left_idx(&self) -> GridIdx2D {
-        let [tile_size_y, tile_size_x] = self.tile_size_in_pixels.into_inner();
-        self.global_tile_position() * [tile_size_y as isize, tile_size_x as isize]
-    }
-
-    pub fn global_upper_right_idx(&self) -> GridIdx2D {
-        self.global_upper_left_idx() + self.local_upper_right_idx()
-    }
-
-    pub fn global_lower_right_idx(&self) -> GridIdx2D {
-        self.global_upper_left_idx() + self.local_lower_right_idx()
-    }
-
-    pub fn global_lower_left_idx(&self) -> GridIdx2D {
-        self.global_upper_left_idx() + self.local_lower_left_idx()
-    }
-
-    pub fn tile_size_in_pixels(&self) -> GridShape2D {
-        self.tile_size_in_pixels
-    }
-
-    pub fn local_to_global_idx(&self, local_pixel_position: GridIdx2D) -> GridIdx2D {
-        self.global_upper_left_idx() + local_pixel_position
-    }
-
-    pub fn tile_geo_transform(&self) -> GeoTransform {
-        let tile_upper_left_coord = self
-            .global_geo_transform
-            .grid_idx_to_coordinate_2d(self.global_upper_left_idx());
-
-        GeoTransform::new(
-            tile_upper_left_coord,
-            self.global_geo_transform.x_pixel_size,
-            self.global_geo_transform.y_pixel_size,
-        )
-    }
-}
-
-impl SpatialBounded for TileInformation {
-    fn spatial_bounds(&self) -> BoundingBox2D {
-        let top_left_coord = self
-            .global_geo_transform
-            .grid_idx_to_coordinate_2d(self.global_upper_left_idx());
-        let lower_right_coord = self
-            .global_geo_transform
-            .grid_idx_to_coordinate_2d(self.global_lower_right_idx() + 1); // we need the border of the lower right pixel.
-        BoundingBox2D::new_upper_left_lower_right_unchecked(top_left_coord, lower_right_coord)
     }
 }
 

--- a/datatypes/src/raster/tiling.rs
+++ b/datatypes/src/raster/tiling.rs
@@ -62,14 +62,6 @@ impl TilingStrategy {
         [y_tile_idx, x_tile_idx].into()
     }
 
-    pub fn pixel_idx_to_next_tile_idx(&self, pixel_idx: GridIdx2D) -> GridIdx2D {
-        let GridIdx([y_pixel_idx, x_pixel_idx]) = pixel_idx;
-        let [y_tile_size, x_tile_size] = self.tile_pixel_size.into_inner();
-        let y_tile_idx = (y_pixel_idx as f32 / y_tile_size as f32).ceil() as isize;
-        let x_tile_idx = (x_pixel_idx as f32 / x_tile_size as f32).ceil() as isize;
-        [y_tile_idx, x_tile_idx].into()
-    }
-
     pub fn pixel_grid_box(&self, bounding_box: BoundingBox2D) -> GridBoundingBox2D {
         let start = self.upper_left_pixel_idx(bounding_box);
         let end = self.lower_right_pixel_idx(bounding_box);

--- a/datatypes/src/raster/tiling.rs
+++ b/datatypes/src/raster/tiling.rs
@@ -69,6 +69,7 @@ impl TilingStrategy {
     }
 
     /// generates the tile idx in [z,y,x] order for the tiles intersecting the bounding box
+    /// the iterator moves once along the x-axis and then increases the y-axis
     pub fn tile_idx_iterator(
         &self,
         bounding_box: BoundingBox2D,
@@ -85,7 +86,8 @@ impl TilingStrategy {
         y_range.flat_map(move |y_tile| x_range.clone().map(move |x_tile| [y_tile, x_tile].into()))
     }
 
-    /// generates the tile idx in [z,y,x] order for the tiles intersecting the bounding box
+    /// generates the tile information for the tiles intersecting the bounding box
+    /// the iterator moves once along the x-axis and then increases the y-axis
     pub fn tile_information_iterator(
         &self,
         bounding_box: BoundingBox2D,

--- a/datatypes/src/raster/tiling.rs
+++ b/datatypes/src/raster/tiling.rs
@@ -12,6 +12,13 @@ pub struct TilingStrategy {
 }
 
 impl TilingStrategy {
+    pub fn new(tile_pixel_size: GridShape2D, geo_transform: GeoTransform) -> Self {
+        Self {
+            tile_pixel_size,
+            geo_transform,
+        }
+    }
+
     pub fn upper_left_pixel_idx(&self, bounding_box: BoundingBox2D) -> GridIdx2D {
         self.geo_transform
             .coordinate_to_grid_idx_2d(bounding_box.upper_left())

--- a/datatypes/src/raster/tiling.rs
+++ b/datatypes/src/raster/tiling.rs
@@ -8,20 +8,20 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 pub struct TilingSpecification {
     pub origin_coordinate: Coordinate2D,
-    pub tile_size: GridShape2D,
+    pub tile_size_in_pixels: GridShape2D,
 }
 
 /// A provider of tile (size) information for a raster/grid
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 pub struct TilingStrategy {
-    pub tile_pixel_size: GridShape2D,
+    pub tile_size_in_pixels: GridShape2D,
     pub geo_transform: GeoTransform,
 }
 
 impl TilingStrategy {
     pub fn new(tile_pixel_size: GridShape2D, geo_transform: GeoTransform) -> Self {
         Self {
-            tile_pixel_size,
+            tile_size_in_pixels: tile_pixel_size,
             geo_transform,
         }
     }
@@ -32,7 +32,7 @@ impl TilingStrategy {
         y_pixel_size: f64,
     ) -> Self {
         Self {
-            tile_pixel_size: tiling_specification.tile_size,
+            tile_size_in_pixels: tiling_specification.tile_size_in_pixels,
             geo_transform: GeoTransform::new(
                 tiling_specification.origin_coordinate,
                 x_pixel_size,
@@ -56,7 +56,7 @@ impl TilingStrategy {
 
     pub fn pixel_idx_to_tile_idx(&self, pixel_idx: GridIdx2D) -> GridIdx2D {
         let GridIdx([y_pixel_idx, x_pixel_idx]) = pixel_idx;
-        let [y_tile_size, x_tile_size] = self.tile_pixel_size.into_inner();
+        let [y_tile_size, x_tile_size] = self.tile_size_in_pixels.into_inner();
         let y_tile_idx = (y_pixel_idx as f32 / y_tile_size as f32).floor() as isize;
         let x_tile_idx = (x_pixel_idx as f32 / x_tile_size as f32).floor() as isize;
         [y_tile_idx, x_tile_idx].into()
@@ -92,7 +92,7 @@ impl TilingStrategy {
         &self,
         bounding_box: BoundingBox2D,
     ) -> impl Iterator<Item = TileInformation> {
-        let tile_pixel_size = self.tile_pixel_size;
+        let tile_pixel_size = self.tile_size_in_pixels;
         let geo_transform = self.geo_transform;
         self.tile_idx_iterator(bounding_box)
             .map(move |idx| TileInformation::new(idx, tile_pixel_size, geo_transform))

--- a/datatypes/src/raster/tiling.rs
+++ b/datatypes/src/raster/tiling.rs
@@ -11,6 +11,20 @@ pub struct TilingSpecification {
     pub tile_size_in_pixels: GridShape2D,
 }
 
+impl TilingSpecification {
+    pub fn new(origin_coordinate: Coordinate2D, tile_size_in_pixels: GridShape2D) -> Self {
+        Self {
+            origin_coordinate,
+            tile_size_in_pixels,
+        }
+    }
+
+    /// create a `TilingStrategy` from self and pixel sizes
+    pub fn strategy(self, x_pixel_size: f64, y_pixel_size: f64) -> TilingStrategy {
+        TilingStrategy::new_with_tiling_spec(self, x_pixel_size, y_pixel_size)
+    }
+}
+
 /// A provider of tile (size) information for a raster/grid
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 pub struct TilingStrategy {

--- a/datatypes/src/raster/tiling.rs
+++ b/datatypes/src/raster/tiling.rs
@@ -68,7 +68,7 @@ impl TilingStrategy {
         GridBoundingBox2D::new_unchecked(start, end)
     }
 
-    /// generates the tile idx for the tiles intersecting the bounding box
+    /// generates the tile idx in [z,y,x] order for the tiles intersecting the bounding box
     pub fn tile_idx_iterator(
         &self,
         bounding_box: BoundingBox2D,
@@ -85,7 +85,7 @@ impl TilingStrategy {
         y_range.flat_map(move |y_tile| x_range.clone().map(move |x_tile| [y_tile, x_tile].into()))
     }
 
-    /// generates the tile idx for the tiles intersecting the bounding box
+    /// generates the tile idx in [z,y,x] order for the tiles intersecting the bounding box
     pub fn tile_information_iterator(
         &self,
         bounding_box: BoundingBox2D,

--- a/datatypes/src/raster/tiling.rs
+++ b/datatypes/src/raster/tiling.rs
@@ -62,12 +62,6 @@ impl TilingStrategy {
         [y_tile_idx, x_tile_idx].into()
     }
 
-    pub fn pixel_grid_box(&self, bounding_box: BoundingBox2D) -> GridBoundingBox2D {
-        let start = self.upper_left_pixel_idx(bounding_box);
-        let end = self.lower_right_pixel_idx(bounding_box);
-        GridBoundingBox2D::new_unchecked(start, end)
-    }
-
     pub fn tile_grid_box(&self, bounding_box: BoundingBox2D) -> GridBoundingBox2D {
         let start = self.pixel_idx_to_tile_idx(self.upper_left_pixel_idx(bounding_box));
         let end = self.pixel_idx_to_tile_idx(self.lower_right_pixel_idx(bounding_box));

--- a/datatypes/src/raster/tiling.rs
+++ b/datatypes/src/raster/tiling.rs
@@ -1,8 +1,15 @@
-use crate::primitives::{BoundingBox2D, SpatialBounded};
+use crate::primitives::{BoundingBox2D, Coordinate2D, SpatialBounded};
 
 use super::{GeoTransform, GridBoundingBox2D, GridIdx, GridIdx2D, GridShape2D, GridSize};
 
 use serde::{Deserialize, Serialize};
+
+/// The static parameters of a `TilingStrategy`
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+pub struct TilingSpecification {
+    pub origin_coordinate: Coordinate2D,
+    pub tile_size: GridShape2D,
+}
 
 /// A provider of tile (size) information for a raster/grid
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
@@ -16,6 +23,21 @@ impl TilingStrategy {
         Self {
             tile_pixel_size,
             geo_transform,
+        }
+    }
+
+    pub fn new_with_tiling_spec(
+        tiling_specification: TilingSpecification,
+        x_pixel_size: f64,
+        y_pixel_size: f64,
+    ) -> Self {
+        Self {
+            tile_pixel_size: tiling_specification.tile_size,
+            geo_transform: GeoTransform::new(
+                tiling_specification.origin_coordinate,
+                x_pixel_size,
+                y_pixel_size,
+            ),
         }
     }
 

--- a/datatypes/src/raster/tiling.rs
+++ b/datatypes/src/raster/tiling.rs
@@ -121,21 +121,21 @@ impl TileInformation {
     }
 
     #[allow(clippy::unused_self)]
-    pub fn local_upper_left_idx(&self) -> GridIdx2D {
+    pub fn local_upper_left_pixel_idx(&self) -> GridIdx2D {
         [0, 0].into()
     }
 
-    pub fn local_lower_left_idx(&self) -> GridIdx2D {
+    pub fn local_lower_left_pixel_idx(&self) -> GridIdx2D {
         [self.tile_size_in_pixels.axis_size_y() as isize - 1, 0].into()
     }
 
-    pub fn local_upper_right_idx(&self) -> GridIdx2D {
+    pub fn local_upper_right_pixel_idx(&self) -> GridIdx2D {
         [0, self.tile_size_in_pixels.axis_size_x() as isize - 1].into()
     }
 
-    pub fn local_lower_right_idx(&self) -> GridIdx2D {
-        let GridIdx([y, _]) = self.local_lower_left_idx();
-        let GridIdx([_, x]) = self.local_upper_right_idx();
+    pub fn local_lower_right_pixel_idx(&self) -> GridIdx2D {
+        let GridIdx([y, _]) = self.local_lower_left_pixel_idx();
+        let GridIdx([_, x]) = self.local_upper_right_pixel_idx();
         [y, x].into()
     }
 
@@ -143,35 +143,35 @@ impl TileInformation {
         self.global_tile_position
     }
 
-    pub fn global_upper_left_idx(&self) -> GridIdx2D {
+    pub fn global_upper_left_pixel_idx(&self) -> GridIdx2D {
         let [tile_size_y, tile_size_x] = self.tile_size_in_pixels.into_inner();
         self.global_tile_position() * [tile_size_y as isize, tile_size_x as isize]
     }
 
-    pub fn global_upper_right_idx(&self) -> GridIdx2D {
-        self.global_upper_left_idx() + self.local_upper_right_idx()
+    pub fn global_upper_right_pixel_idx(&self) -> GridIdx2D {
+        self.global_upper_left_pixel_idx() + self.local_upper_right_pixel_idx()
     }
 
-    pub fn global_lower_right_idx(&self) -> GridIdx2D {
-        self.global_upper_left_idx() + self.local_lower_right_idx()
+    pub fn global_lower_right_pixel_idx(&self) -> GridIdx2D {
+        self.global_upper_left_pixel_idx() + self.local_lower_right_pixel_idx()
     }
 
-    pub fn global_lower_left_idx(&self) -> GridIdx2D {
-        self.global_upper_left_idx() + self.local_lower_left_idx()
+    pub fn global_lower_left_pixel_idx(&self) -> GridIdx2D {
+        self.global_upper_left_pixel_idx() + self.local_lower_left_pixel_idx()
     }
 
     pub fn tile_size_in_pixels(&self) -> GridShape2D {
         self.tile_size_in_pixels
     }
 
-    pub fn local_to_global_idx(&self, local_pixel_position: GridIdx2D) -> GridIdx2D {
-        self.global_upper_left_idx() + local_pixel_position
+    pub fn local_to_global_pixel_idx(&self, local_pixel_position: GridIdx2D) -> GridIdx2D {
+        self.global_upper_left_pixel_idx() + local_pixel_position
     }
 
     pub fn tile_geo_transform(&self) -> GeoTransform {
         let tile_upper_left_coord = self
             .global_geo_transform
-            .grid_idx_to_coordinate_2d(self.global_upper_left_idx());
+            .grid_idx_to_coordinate_2d(self.global_upper_left_pixel_idx());
 
         GeoTransform::new(
             tile_upper_left_coord,
@@ -185,10 +185,10 @@ impl SpatialBounded for TileInformation {
     fn spatial_bounds(&self) -> BoundingBox2D {
         let top_left_coord = self
             .global_geo_transform
-            .grid_idx_to_coordinate_2d(self.global_upper_left_idx());
+            .grid_idx_to_coordinate_2d(self.global_upper_left_pixel_idx());
         let lower_right_coord = self
             .global_geo_transform
-            .grid_idx_to_coordinate_2d(self.global_lower_right_idx() + 1); // we need the border of the lower right pixel.
+            .grid_idx_to_coordinate_2d(self.global_lower_right_pixel_idx() + 1); // we need the border of the lower right pixel.
         BoundingBox2D::new_upper_left_lower_right_unchecked(top_left_coord, lower_right_coord)
     }
 }

--- a/operators/src/adapters/raster_time.rs
+++ b/operators/src/adapters/raster_time.rs
@@ -175,11 +175,11 @@ mod tests {
     };
     use crate::mock::{MockRasterSource, MockRasterSourceParams};
     use futures::StreamExt;
-    use geoengine_datatypes::raster::{Grid, GridShape2D, RasterDataType};
+    use geoengine_datatypes::primitives::{BoundingBox2D, SpatialResolution};
     use geoengine_datatypes::spatial_reference::SpatialReference;
     use geoengine_datatypes::{
-        primitives::{BoundingBox2D, SpatialResolution},
-        raster::GeoTransform,
+        primitives::Coordinate2D,
+        raster::{Grid, GridShape2D, RasterDataType, TilingSpecification},
     };
 
     #[tokio::test]
@@ -306,9 +306,9 @@ mod tests {
         let exe_ctx = ExecutionContext {
             raster_data_root: Default::default(),
             thread_pool: thread_pool.create_context(),
-            tiling_strategy: TilingStrategy {
-                geo_transform: GeoTransform::default(),
-                tile_pixel_size: GridShape2D::from([600, 600]),
+            tiling_specification: TilingSpecification {
+                origin_coordinate: Coordinate2D::default(),
+                tile_size: GridShape2D::from([600, 600]),
             },
         };
         let query_rect = QueryRectangle {

--- a/operators/src/adapters/raster_time.rs
+++ b/operators/src/adapters/raster_time.rs
@@ -75,12 +75,11 @@ where
     fn number_of_tiles_in_bbox(tile_info: &TileInformation, bbox: BoundingBox2D) -> usize {
         // TODO: get tiling strategy from stream or execution context instead of creating it here
         let strat = TilingStrategy {
-            bounding_box: bbox,
             tile_pixel_size: tile_info.tile_size_in_pixels,
             geo_transform: tile_info.global_geo_transform,
         };
 
-        strat.tile_grid_box().number_of_elements()
+        strat.tile_grid_box(bbox).number_of_elements()
     }
 }
 

--- a/operators/src/adapters/raster_time.rs
+++ b/operators/src/adapters/raster_time.rs
@@ -75,7 +75,7 @@ where
     fn number_of_tiles_in_bbox(tile_info: &TileInformation, bbox: BoundingBox2D) -> usize {
         // TODO: get tiling strategy from stream or execution context instead of creating it here
         let strat = TilingStrategy {
-            tile_pixel_size: tile_info.tile_size_in_pixels,
+            tile_size_in_pixels: tile_info.tile_size_in_pixels,
             geo_transform: tile_info.global_geo_transform,
         };
 
@@ -308,7 +308,7 @@ mod tests {
             thread_pool: thread_pool.create_context(),
             tiling_specification: TilingSpecification {
                 origin_coordinate: Coordinate2D::default(),
-                tile_size: GridShape2D::from([600, 600]),
+                tile_size_in_pixels: GridShape2D::from([600, 600]),
             },
         };
         let query_rect = QueryRectangle {

--- a/operators/src/adapters/raster_time.rs
+++ b/operators/src/adapters/raster_time.rs
@@ -1,11 +1,10 @@
 use crate::engine::QueryRectangle;
-use crate::source::TilingStrategy;
 use crate::util::Result;
 use futures::stream::{FusedStream, Zip};
 use futures::Stream;
 use futures::{ready, StreamExt};
 use geoengine_datatypes::primitives::{BoundingBox2D, TimeInstance, TimeInterval};
-use geoengine_datatypes::raster::{GridSize, Pixel, RasterTile2D, TileInformation};
+use geoengine_datatypes::raster::{GridSize, Pixel, RasterTile2D, TileInformation, TilingStrategy};
 use pin_project::pin_project;
 use std::cmp::min;
 use std::pin::Pin;

--- a/operators/src/adapters/raster_time.rs
+++ b/operators/src/adapters/raster_time.rs
@@ -175,9 +175,12 @@ mod tests {
     };
     use crate::mock::{MockRasterSource, MockRasterSourceParams};
     use futures::StreamExt;
-    use geoengine_datatypes::primitives::{BoundingBox2D, SpatialResolution};
-    use geoengine_datatypes::raster::{Grid, RasterDataType};
+    use geoengine_datatypes::raster::{Grid, GridShape2D, RasterDataType};
     use geoengine_datatypes::spatial_reference::SpatialReference;
+    use geoengine_datatypes::{
+        primitives::{BoundingBox2D, SpatialResolution},
+        raster::GeoTransform,
+    };
 
     #[tokio::test]
     async fn adapter() {
@@ -303,6 +306,10 @@ mod tests {
         let exe_ctx = ExecutionContext {
             raster_data_root: Default::default(),
             thread_pool: thread_pool.create_context(),
+            tiling_strategy: TilingStrategy {
+                geo_transform: GeoTransform::default(),
+                tile_pixel_size: GridShape2D::from([600, 600]),
+            },
         };
         let query_rect = QueryRectangle {
             bbox: BoundingBox2D::new_unchecked((0., 0.).into(), (1., 1.).into()),

--- a/operators/src/engine/execution_context.rs
+++ b/operators/src/engine/execution_context.rs
@@ -39,7 +39,7 @@ impl Default for MockExecutionContextCreator {
             thread_pool: ThreadPool::new(1),
             tiling_specification: TilingSpecification {
                 origin_coordinate: Coordinate2D::default(),
-                tile_size: GridShape2D::from([600, 600]),
+                tile_size_in_pixels: GridShape2D::from([600, 600]),
             },
         }
     }

--- a/operators/src/engine/execution_context.rs
+++ b/operators/src/engine/execution_context.rs
@@ -1,4 +1,7 @@
-use geoengine_datatypes::raster::{GeoTransform, GridShape2D, TilingStrategy};
+use geoengine_datatypes::{
+    primitives::Coordinate2D,
+    raster::{GridShape2D, TilingSpecification},
+};
 
 use crate::concurrency::{ThreadPool, ThreadPoolContext};
 use std::path::PathBuf;
@@ -9,14 +12,14 @@ use std::path::PathBuf;
 pub struct ExecutionContext<'pool> {
     pub raster_data_root: PathBuf,
     pub thread_pool: ThreadPoolContext<'pool>,
-    pub tiling_strategy: TilingStrategy,
+    pub tiling_specification: TilingSpecification,
 }
 
 /// Create a provider for execution contexts in test environments
 pub struct MockExecutionContextCreator {
     raster_data_root: PathBuf,
     thread_pool: ThreadPool,
-    tiling_strategy: TilingStrategy,
+    tiling_specification: TilingSpecification,
 }
 
 impl MockExecutionContextCreator {
@@ -24,7 +27,7 @@ impl MockExecutionContextCreator {
         ExecutionContext {
             raster_data_root: self.raster_data_root.clone(),
             thread_pool: self.thread_pool.create_context(),
-            tiling_strategy: self.tiling_strategy,
+            tiling_specification: self.tiling_specification,
         }
     }
 }
@@ -34,10 +37,10 @@ impl Default for MockExecutionContextCreator {
         Self {
             raster_data_root: PathBuf::default(),
             thread_pool: ThreadPool::new(1),
-            tiling_strategy: TilingStrategy::new(
-                GridShape2D::new([600, 600]),
-                GeoTransform::default(),
-            ),
+            tiling_specification: TilingSpecification {
+                origin_coordinate: Coordinate2D::default(),
+                tile_size: GridShape2D::from([600, 600]),
+            },
         }
     }
 }

--- a/operators/src/engine/execution_context.rs
+++ b/operators/src/engine/execution_context.rs
@@ -1,3 +1,5 @@
+use geoengine_datatypes::raster::{GeoTransform, GridShape2D, TilingStrategy};
+
 use crate::concurrency::{ThreadPool, ThreadPoolContext};
 use std::path::PathBuf;
 
@@ -7,12 +9,14 @@ use std::path::PathBuf;
 pub struct ExecutionContext<'pool> {
     pub raster_data_root: PathBuf,
     pub thread_pool: ThreadPoolContext<'pool>,
+    pub tiling_strategy: TilingStrategy,
 }
 
 /// Create a provider for execution contexts in test environments
 pub struct MockExecutionContextCreator {
     raster_data_root: PathBuf,
     thread_pool: ThreadPool,
+    tiling_strategy: TilingStrategy,
 }
 
 impl MockExecutionContextCreator {
@@ -20,6 +24,7 @@ impl MockExecutionContextCreator {
         ExecutionContext {
             raster_data_root: self.raster_data_root.clone(),
             thread_pool: self.thread_pool.create_context(),
+            tiling_strategy: self.tiling_strategy,
         }
     }
 }
@@ -29,6 +34,10 @@ impl Default for MockExecutionContextCreator {
         Self {
             raster_data_root: PathBuf::default(),
             thread_pool: ThreadPool::new(1),
+            tiling_strategy: TilingStrategy::new(
+                GridShape2D::new([600, 600]),
+                GeoTransform::default(),
+            ),
         }
     }
 }

--- a/operators/src/source/gdal_source.rs
+++ b/operators/src/source/gdal_source.rs
@@ -536,7 +536,7 @@ impl RasterOperator for GdalSource {
         let init = InitializedGdalSourceOperator {
             provider,
             result_descriptor: RasterResultDescriptor {
-                data_type: data_type,
+                data_type,
                 spatial_reference: SpatialReference::wgs84().into(), // TODO: lookup from dataset
             },
             tiling_specification: context.tiling_specification,

--- a/operators/src/source/gdal_source.rs
+++ b/operators/src/source/gdal_source.rs
@@ -694,7 +694,7 @@ mod tests {
         let bounding_box = BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap();
 
         let origin_split_tileing_strategy = TilingStrategy {
-            tile_pixel_size: tile_size_in_pixels.into(),
+            tile_size_in_pixels: tile_size_in_pixels.into(),
             geo_transform: dataset_geo_transform,
         };
 
@@ -728,7 +728,7 @@ mod tests {
         let bounding_box = BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap();
 
         let origin_split_tileing_strategy = TilingStrategy {
-            tile_pixel_size: tile_size_in_pixels.into(),
+            tile_size_in_pixels: tile_size_in_pixels.into(),
             geo_transform: central_geo_transform,
         };
 
@@ -762,7 +762,7 @@ mod tests {
         let bounding_box = BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap();
 
         let origin_split_tileing_strategy = TilingStrategy {
-            tile_pixel_size: tile_size_in_pixels.into(),
+            tile_size_in_pixels: tile_size_in_pixels.into(),
             geo_transform: central_geo_transform,
         };
 
@@ -792,7 +792,7 @@ mod tests {
         let bounding_box = BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap();
 
         let origin_split_tileing_strategy = TilingStrategy {
-            tile_pixel_size: tile_size_in_pixels.into(),
+            tile_size_in_pixels: tile_size_in_pixels.into(),
             geo_transform: central_geo_transform,
         };
 
@@ -879,13 +879,13 @@ mod tests {
             gdal_params,
             tiling_specification: TilingSpecification {
                 origin_coordinate: central_geo_transform.origin_coordinate,
-                tile_size: GridShape2D::from(tile_size_in_pixels),
+                tile_size_in_pixels: GridShape2D::from(tile_size_in_pixels),
             },
             phantom_data: PhantomData,
         };
 
         let origin_split_tileing_strategy = TilingStrategy {
-            tile_pixel_size: tile_size_in_pixels.into(),
+            tile_size_in_pixels: tile_size_in_pixels.into(),
             geo_transform: central_geo_transform,
         };
 
@@ -990,7 +990,7 @@ mod tests {
             gdal_params,
             tiling_specification: TilingSpecification {
                 origin_coordinate: Coordinate2D::default(),
-                tile_size: GridShape2D::from(tile_size_in_pixels),
+                tile_size_in_pixels: GridShape2D::from(tile_size_in_pixels),
             },
             phantom_data: PhantomData,
         };
@@ -1057,7 +1057,7 @@ mod tests {
             gdal_params,
             tiling_specification: TilingSpecification {
                 origin_coordinate: Coordinate2D::new(0., 0.),
-                tile_size: GridShape2D::from(tile_size_in_pixels),
+                tile_size_in_pixels: GridShape2D::from(tile_size_in_pixels),
             },
             phantom_data: PhantomData,
         };
@@ -1102,7 +1102,7 @@ mod tests {
         let bounding_box = BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap();
 
         let origin_split_tileing_strategy = TilingStrategy {
-            tile_pixel_size: tile_size_in_pixels.into(),
+            tile_size_in_pixels: tile_size_in_pixels.into(),
             geo_transform: dataset_geo_transform,
         };
 
@@ -1140,7 +1140,7 @@ mod tests {
             gdal_params,
             tiling_specification: TilingSpecification {
                 origin_coordinate: Coordinate2D::new(0., 0.),
-                tile_size: GridShape2D::from(tile_size_in_pixels),
+                tile_size_in_pixels: GridShape2D::from(tile_size_in_pixels),
             },
             phantom_data: PhantomData,
         };
@@ -1199,7 +1199,7 @@ mod tests {
         let bounding_box = BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap();
 
         let origin_split_tileing_strategy = TilingStrategy {
-            tile_pixel_size: tile_size_in_pixels.into(),
+            tile_size_in_pixels: tile_size_in_pixels.into(),
             geo_transform: center_geo_transform,
         };
 
@@ -1237,7 +1237,7 @@ mod tests {
             gdal_params,
             tiling_specification: TilingSpecification {
                 origin_coordinate: Coordinate2D::new(0., 0.),
-                tile_size: GridShape2D::from(tile_size_in_pixels),
+                tile_size_in_pixels: GridShape2D::from(tile_size_in_pixels),
             },
             phantom_data: PhantomData,
         };
@@ -1322,7 +1322,7 @@ mod tests {
             gdal_params,
             tiling_specification: TilingSpecification {
                 origin_coordinate: Coordinate2D::new(0., 0.),
-                tile_size: GridShape2D::from(tile_size_in_pixels),
+                tile_size_in_pixels: GridShape2D::from(tile_size_in_pixels),
             },
             phantom_data: PhantomData,
         };
@@ -1330,7 +1330,7 @@ mod tests {
         let query_bbox = BoundingBox2D::new((-30., 0.).into(), (35., 65.).into()).unwrap();
 
         let origin_split_tileing_strategy = TilingStrategy {
-            tile_pixel_size: tile_size_in_pixels.into(),
+            tile_size_in_pixels: tile_size_in_pixels.into(),
             geo_transform: dataset_geo_transform,
         };
 
@@ -1415,7 +1415,7 @@ mod tests {
                 gdal_params,
                 tiling_specification: TilingSpecification {
                     origin_coordinate: Coordinate2D::new(0., 0.),
-                    tile_size: GridShape2D::from(tile_size_in_pixels),
+                    tile_size_in_pixels: GridShape2D::from(tile_size_in_pixels),
                 },
                 phantom_data: PhantomData,
             };

--- a/operators/src/source/mod.rs
+++ b/operators/src/source/mod.rs
@@ -5,7 +5,5 @@ mod ogr_source;
 pub use self::csv::{
     CsvGeometrySpecification, CsvSource, CsvSourceParameters, CsvSourceStream, CsvTimeSpecification,
 };
-pub use self::gdal_source::{
-    GdalSource, GdalSourceParameters, GdalSourceProcessor, TilingStrategy,
-};
+pub use self::gdal_source::{GdalSource, GdalSourceParameters, GdalSourceProcessor};
 pub use self::ogr_source::{OgrSource, OgrSourceParameters};

--- a/services/src/handlers/wms.rs
+++ b/services/src/handlers/wms.rs
@@ -6,7 +6,7 @@ use geoengine_datatypes::{
     operations::image::{Colorizer, ToPng},
     primitives::SpatialResolution,
     raster::Grid2D,
-    raster::RasterTile2D,
+    raster::{GridShape2D, RasterTile2D, TilingStrategy},
 };
 use geoengine_datatypes::{
     primitives::BoundingBox2D,
@@ -148,6 +148,10 @@ async fn get_map<C: Context>(
     let execution_context = ExecutionContext {
         raster_data_root: get_config_element::<config::GdalSource>()?.raster_data_root_path,
         thread_pool: thread_pool.create_context(),
+        tiling_strategy: TilingStrategy {
+            tile_pixel_size: GridShape2D::from([600, 600]),
+            geo_transform: GeoTransform::default(),
+        },
     };
 
     let initialized = operator

--- a/services/src/handlers/wms.rs
+++ b/services/src/handlers/wms.rs
@@ -145,12 +145,20 @@ async fn get_map<C: Context>(
     let operator = workflow.operator.get_raster().context(error::Operator)?;
 
     let thread_pool = ThreadPool::new(1); // TODO: use global thread pool
+
+    let config_tiling_spec = get_config_element::<config::TilingSpecification>()?;
     let execution_context = ExecutionContext {
         raster_data_root: get_config_element::<config::GdalSource>()?.raster_data_root_path,
         thread_pool: thread_pool.create_context(),
         tiling_specification: TilingSpecification {
-            origin_coordinate: Coordinate2D::default(),
-            tile_size_in_pixels: GridShape2D::from([600, 600]),
+            origin_coordinate: Coordinate2D::new(
+                config_tiling_spec.origin_coordinate_x,
+                config_tiling_spec.origin_coordinate_y,
+            ),
+            tile_size_in_pixels: GridShape2D::from([
+                config_tiling_spec.tile_shape_pixels_y,
+                config_tiling_spec.tile_shape_pixels_x,
+            ]),
         },
     };
 

--- a/services/src/handlers/wms.rs
+++ b/services/src/handlers/wms.rs
@@ -150,7 +150,7 @@ async fn get_map<C: Context>(
         thread_pool: thread_pool.create_context(),
         tiling_specification: TilingSpecification {
             origin_coordinate: Coordinate2D::default(),
-            tile_size: GridShape2D::from([600, 600]),
+            tile_size_in_pixels: GridShape2D::from([600, 600]),
         },
     };
 
@@ -347,7 +347,7 @@ mod tests {
             &PathBuf::from("../operators/test-data/raster"),
             TilingSpecification {
                 origin_coordinate: Coordinate2D::new(0., 0.),
-                tile_size: GridShape2D::from([600, 600]),
+                tile_size_in_pixels: GridShape2D::from([600, 600]),
             },
         )
         .unwrap();
@@ -402,7 +402,7 @@ mod tests {
             PathBuf::from("../operators/test-data/raster").as_ref(),
             TilingSpecification {
                 origin_coordinate: Coordinate2D::new(0., 0.),
-                tile_size: GridShape2D::from([600, 600]),
+                tile_size_in_pixels: GridShape2D::from([600, 600]),
             },
         )
         .unwrap();

--- a/services/src/handlers/wms.rs
+++ b/services/src/handlers/wms.rs
@@ -4,9 +4,9 @@ use warp::{http::Response, Filter, Rejection};
 
 use geoengine_datatypes::{
     operations::image::{Colorizer, ToPng},
-    primitives::SpatialResolution,
+    primitives::{Coordinate2D, SpatialResolution},
     raster::Grid2D,
-    raster::{GridShape2D, RasterTile2D, TilingStrategy},
+    raster::{GridShape2D, RasterTile2D, TilingSpecification},
 };
 use geoengine_datatypes::{
     primitives::BoundingBox2D,
@@ -148,9 +148,9 @@ async fn get_map<C: Context>(
     let execution_context = ExecutionContext {
         raster_data_root: get_config_element::<config::GdalSource>()?.raster_data_root_path,
         thread_pool: thread_pool.create_context(),
-        tiling_strategy: TilingStrategy {
-            tile_pixel_size: GridShape2D::from([600, 600]),
-            geo_transform: GeoTransform::default(),
+        tiling_specification: TilingSpecification {
+            origin_coordinate: Coordinate2D::default(),
+            tile_size: GridShape2D::from([600, 600]),
         },
     };
 
@@ -345,6 +345,10 @@ mod tests {
         let gdal_source = GdalSourceProcessor::<_, u8>::from_params_with_json_provider(
             gdal_params,
             &PathBuf::from("../operators/test-data/raster"),
+            TilingSpecification {
+                origin_coordinate: Coordinate2D::new(0., 0.),
+                tile_size: GridShape2D::from([600, 600]),
+            },
         )
         .unwrap();
 
@@ -396,6 +400,10 @@ mod tests {
         let gdal_source = GdalSourceProcessor::<_, u8>::from_params_with_json_provider(
             gdal_params,
             PathBuf::from("../operators/test-data/raster").as_ref(),
+            TilingSpecification {
+                origin_coordinate: Coordinate2D::new(0., 0.),
+                tile_size: GridShape2D::from([600, 600]),
+            },
         )
         .unwrap();
 

--- a/services/src/util/config.rs
+++ b/services/src/util/config.rs
@@ -135,3 +135,15 @@ pub struct GdalSource {
 impl ConfigElement for GdalSource {
     const KEY: &'static str = "operators.gdal_source";
 }
+
+#[derive(Debug, Deserialize)]
+pub struct TilingSpecification {
+    pub origin_coordinate_x: f64,
+    pub origin_coordinate_y: f64,
+    pub tile_shape_pixels_x: usize,
+    pub tile_shape_pixels_y: usize,
+}
+
+impl ConfigElement for TilingSpecification {
+    const KEY: &'static str = "raster.tiling_specification";
+}


### PR DESCRIPTION
This PR
- moves TilingStrategy from GdalSource to Promitives.
- Adds a TilingSpecification to define origin and tile size
- Uses TilingSpecification in the ExecutionContext and generates a TilingStrategy for each query in the GdalSource