### PR TITLE
handle_reprojection_part2

### DIFF
--- a/datatypes/src/collections/feature_collection.rs
+++ b/datatypes/src/collections/feature_collection.rs
@@ -1336,7 +1336,7 @@ where
         // get the coordinates
         let coords_ref = self.coordinates();
         // reproject them...
-        let projected_coords = projector.project_coordinate_slice_copy(coords_ref)?;
+        let projected_coords = projector.project_coordinates(coords_ref)?;
 
         // transform the coordinates into a byte slice and create a Buffer from it.
         let coords_buffer = unsafe {

--- a/datatypes/src/collections/feature_collection.rs
+++ b/datatypes/src/collections/feature_collection.rs
@@ -1366,7 +1366,7 @@ where
             G::arrow_data_type(),
             false,
         ));
-        column_values.push(Arc::new(ListArray::from(multi_polygon_array)));
+        column_values.push(Arc::new(ListArray::from(feature_array)));
         // }
 
         // copy time data

--- a/datatypes/src/collections/feature_collection.rs
+++ b/datatypes/src/collections/feature_collection.rs
@@ -1353,7 +1353,7 @@ where
             .column_by_name(Self::GEOMETRY_COLUMN_NAME)
             .expect("There must exist a geometry column");
 
-        let multi_polygon_array = Self::replace_raw_coords(geometries_ref, coords_buffer);
+        let feature_array = Self::replace_raw_coords(geometries_ref, coords_buffer);
 
         let mut columns = Vec::<arrow::datatypes::Field>::with_capacity(self.table.num_columns());
         let mut column_values =

--- a/datatypes/src/collections/geo_feature_collection.rs
+++ b/datatypes/src/collections/geo_feature_collection.rs
@@ -1,3 +1,10 @@
+use std::sync::Arc;
+
+use arrow::{
+    array::{Array, ArrayData},
+    buffer::Buffer,
+};
+
 use crate::primitives::{Coordinate2D, GeometryRef};
 
 /// This trait allows iterating over the geometries of a feature collection
@@ -31,4 +38,8 @@ pub trait GeometryCollection {
     fn coordinates(&self) -> &[Coordinate2D];
 
     fn feature_offsets(&self) -> &[i32];
+}
+
+pub trait ReplaceRawArrayCoords {
+    fn replace_raw_coords(array_ref: &Arc<dyn Array>, new_coord_buffer: Buffer) -> Arc<ArrayData>;
 }

--- a/datatypes/src/collections/multi_line_string_collection.rs
+++ b/datatypes/src/collections/multi_line_string_collection.rs
@@ -1,20 +1,10 @@
+use crate::collections::{
+    FeatureCollection, FeatureCollectionInfos, FeatureCollectionRowBuilder,
+    GeoFeatureCollectionRowBuilder, GeometryCollection, GeometryRandomAccess, IntoGeometryIterator,
+};
+use crate::primitives::{Coordinate2D, MultiLineString, MultiLineStringAccess, MultiLineStringRef};
+use crate::util::arrow::{downcast_array, ArrowTyped};
 use crate::util::Result;
-use crate::{
-    collections::{
-        FeatureCollection, FeatureCollectionInfos, FeatureCollectionRowBuilder,
-        GeoFeatureCollectionRowBuilder, GeometryCollection, GeometryRandomAccess,
-        IntoGeometryIterator,
-    },
-    operations::reproject::Reproject,
-};
-use crate::{
-    operations::reproject::CoordinateProjection,
-    primitives::{Coordinate2D, MultiLineString, MultiLineStringAccess, MultiLineStringRef},
-};
-use crate::{
-    primitives::TimeInterval,
-    util::arrow::{downcast_array, ArrowTyped},
-};
 use arrow::{
     array::{Array, ArrayData, FixedSizeListArray, Float64Array, ListArray},
     buffer::Buffer,
@@ -22,7 +12,7 @@ use arrow::{
 };
 use std::{slice, sync::Arc};
 
-use super::feature_collection::struct_array_from_data;
+use super::geo_feature_collection::ReplaceRawArrayCoords;
 
 /// This collection contains temporal `MultiLineString`s and miscellaneous data.
 pub type MultiLineStringCollection = FeatureCollection<MultiLineString>;
@@ -237,35 +227,12 @@ impl GeoFeatureCollectionRowBuilder<MultiLineString>
     }
 }
 
-impl<P> Reproject<P> for MultiLineStringCollection
-where
-    P: CoordinateProjection,
-{
-    type Out = MultiLineStringCollection;
-
-    fn reproject(&self, projector: &P) -> Result<Self::Out> {
-        // get the coordinates
-        let coords_ref = self.coordinates();
-        // reproject them...
-        let projected_coords = projector.project_coordinate_slice_copy(coords_ref)?;
-
-        // transform the coordinates into a byte slice and create a Buffer from it.
-        let coords_buffer = unsafe {
-            let coord_bytes: &[u8] = std::slice::from_raw_parts(
-                projected_coords.as_ptr().cast::<u8>(),
-                projected_coords.len() * std::mem::size_of::<Coordinate2D>(),
-            );
-            Buffer::from(coord_bytes)
-        };
-
-        // get the offsets (reuse)
-        let geometries_ref = self
-            .table
-            .column_by_name(Self::GEOMETRY_COLUMN_NAME)
-            .expect("There must exist a geometry column");
-        let geometries: &ListArray = downcast_array(geometries_ref);
+impl ReplaceRawArrayCoords for MultiLineStringCollection {
+    fn replace_raw_coords(array_ref: &Arc<dyn Array>, new_coords: Buffer) -> Arc<ArrayData> {
+        let geometries: &ListArray = downcast_array(array_ref);
 
         let feature_offset_array = geometries.data();
+
         let feature_offsets_buffer = &feature_offset_array.buffers()[0];
         let num_features = (feature_offsets_buffer.len() / std::mem::size_of::<i32>()) - 1;
 
@@ -273,10 +240,10 @@ where
         let line_offsets_buffer = &line_offsets_array.buffers()[0];
         let num_lines = (line_offsets_buffer.len() / std::mem::size_of::<i32>()) - 1;
 
-        let num_coords = coords_buffer.len() / std::mem::size_of::<Coordinate2D>();
+        let num_coords = new_coords.len() / std::mem::size_of::<Coordinate2D>();
         let num_floats = num_coords * 2;
 
-        let multi_line_string_array = ArrayData::builder(MultiLineString::arrow_data_type())
+        ArrayData::builder(MultiLineString::arrow_data_type())
             .len(num_features)
             .add_buffer(feature_offsets_buffer.clone())
             .add_child_data(
@@ -289,61 +256,14 @@ where
                             .add_child_data(
                                 ArrayData::builder(DataType::Float64)
                                     .len(num_floats)
-                                    .add_buffer(coords_buffer)
+                                    .add_buffer(new_coords)
                                     .build(),
                             )
                             .build(),
                     )
                     .build(),
             )
-            .build();
-
-        let mut columns = Vec::<arrow::datatypes::Field>::with_capacity(self.table.num_columns());
-        let mut column_values =
-            Vec::<arrow::array::ArrayRef>::with_capacity(self.table.num_columns());
-
-        // copy geometry data if feature collection is geo collection
-        // if CollectionType::IS_GEOMETRY {
-        columns.push(arrow::datatypes::Field::new(
-            Self::GEOMETRY_COLUMN_NAME,
-            MultiLineString::arrow_data_type(),
-            false,
-        ));
-        column_values.push(Arc::new(ListArray::from(multi_line_string_array)));
-        // }
-
-        // copy time data
-        columns.push(arrow::datatypes::Field::new(
-            Self::TIME_COLUMN_NAME,
-            TimeInterval::arrow_data_type(),
-            false,
-        ));
-        column_values.push(
-            self.table
-                .column_by_name(Self::TIME_COLUMN_NAME)
-                .expect("The time column must exist")
-                .clone(),
-        );
-
-        // copy remaining attribute data
-        for (column_name, column_type) in &self.types {
-            columns.push(arrow::datatypes::Field::new(
-                &column_name,
-                column_type.arrow_data_type(),
-                column_type.nullable(),
-            ));
-            column_values.push(
-                self.table
-                    .column_by_name(&column_name)
-                    .expect("The attribute column must exist")
-                    .clone(),
-            );
-        }
-
-        Ok(Self::new_from_internals(
-            struct_array_from_data(columns, column_values, self.table.len()),
-            self.types.clone(),
-        ))
+            .build()
     }
 }
 
@@ -607,7 +527,7 @@ mod tests {
 
     #[test]
     fn reproject_multi_lines_epsg4326_epsg900913_collection() {
-        use crate::operations::reproject::{CoordinateProjection, CoordinateProjector};
+        use crate::operations::reproject::{CoordinateProjection, CoordinateProjector, Reproject};
         use crate::spatial_reference::{SpatialReference, SpatialReferenceAuthority};
 
         use crate::util::well_known_data::{

--- a/datatypes/src/collections/multi_line_string_collection.rs
+++ b/datatypes/src/collections/multi_line_string_collection.rs
@@ -1,12 +1,28 @@
-use crate::collections::{
-    FeatureCollection, FeatureCollectionInfos, FeatureCollectionRowBuilder,
-    GeoFeatureCollectionRowBuilder, GeometryCollection, GeometryRandomAccess, IntoGeometryIterator,
-};
-use crate::primitives::{Coordinate2D, MultiLineString, MultiLineStringAccess, MultiLineStringRef};
-use crate::util::arrow::downcast_array;
 use crate::util::Result;
-use arrow::array::{Array, FixedSizeListArray, Float64Array, ListArray};
-use std::slice;
+use crate::{
+    collections::{
+        FeatureCollection, FeatureCollectionInfos, FeatureCollectionRowBuilder,
+        GeoFeatureCollectionRowBuilder, GeometryCollection, GeometryRandomAccess,
+        IntoGeometryIterator,
+    },
+    operations::reproject::Reproject,
+};
+use crate::{
+    operations::reproject::CoordinateProjection,
+    primitives::{Coordinate2D, MultiLineString, MultiLineStringAccess, MultiLineStringRef},
+};
+use crate::{
+    primitives::TimeInterval,
+    util::arrow::{downcast_array, ArrowTyped},
+};
+use arrow::{
+    array::{Array, ArrayData, FixedSizeListArray, Float64Array, ListArray},
+    buffer::Buffer,
+    datatypes::DataType,
+};
+use std::{slice, sync::Arc};
+
+use super::feature_collection::struct_array_from_data;
 
 /// This collection contains temporal `MultiLineString`s and miscellaneous data.
 pub type MultiLineStringCollection = FeatureCollection<MultiLineString>;
@@ -218,6 +234,116 @@ impl GeoFeatureCollectionRowBuilder<MultiLineString>
         self.geometries_builder.append(true)?;
 
         Ok(())
+    }
+}
+
+impl<P> Reproject<P> for MultiLineStringCollection
+where
+    P: CoordinateProjection,
+{
+    type Out = MultiLineStringCollection;
+
+    fn reproject(&self, projector: &P) -> Result<Self::Out> {
+        // get the coordinates
+        let coords_ref = self.coordinates();
+        // reproject them...
+        let projected_coords = projector.project_coordinate_slice_copy(coords_ref)?;
+
+        // transform the coordinates into a byte slice and create a Buffer from it.
+        let coords_buffer = unsafe {
+            let coord_bytes: &[u8] = std::slice::from_raw_parts(
+                projected_coords.as_ptr().cast::<u8>(),
+                projected_coords.len() * std::mem::size_of::<Coordinate2D>(),
+            );
+            Buffer::from(coord_bytes)
+        };
+
+        // get the offsets (reuse)
+        let geometries_ref = self
+            .table
+            .column_by_name(Self::GEOMETRY_COLUMN_NAME)
+            .expect("There must exist a geometry column");
+        let geometries: &ListArray = downcast_array(geometries_ref);
+
+        let feature_offset_array = geometries.data();
+        let feature_offsets_buffer = &feature_offset_array.buffers()[0];
+        let num_features = (feature_offsets_buffer.len() / std::mem::size_of::<i32>()) - 1;
+
+        let line_offsets_array = &feature_offset_array.child_data()[0];
+        let line_offsets_buffer = &line_offsets_array.buffers()[0];
+        let num_lines = (line_offsets_buffer.len() / std::mem::size_of::<i32>()) - 1;
+
+        let num_coords = coords_buffer.len() / std::mem::size_of::<Coordinate2D>();
+        let num_floats = num_coords * 2;
+
+        let multi_line_string_array = ArrayData::builder(MultiLineString::arrow_data_type())
+            .len(num_features)
+            .add_buffer(feature_offsets_buffer.clone())
+            .add_child_data(
+                ArrayData::builder(Coordinate2D::arrow_list_data_type())
+                    .len(num_lines)
+                    .add_buffer(line_offsets_buffer.clone())
+                    .add_child_data(
+                        ArrayData::builder(Coordinate2D::arrow_data_type())
+                            .len(num_coords)
+                            .add_child_data(
+                                ArrayData::builder(DataType::Float64)
+                                    .len(num_floats)
+                                    .add_buffer(coords_buffer)
+                                    .build(),
+                            )
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build();
+
+        let mut columns = Vec::<arrow::datatypes::Field>::with_capacity(self.table.num_columns());
+        let mut column_values =
+            Vec::<arrow::array::ArrayRef>::with_capacity(self.table.num_columns());
+
+        // copy geometry data if feature collection is geo collection
+        // if CollectionType::IS_GEOMETRY {
+        columns.push(arrow::datatypes::Field::new(
+            Self::GEOMETRY_COLUMN_NAME,
+            MultiLineString::arrow_data_type(),
+            false,
+        ));
+        column_values.push(Arc::new(ListArray::from(multi_line_string_array)));
+        // }
+
+        // copy time data
+        columns.push(arrow::datatypes::Field::new(
+            Self::TIME_COLUMN_NAME,
+            TimeInterval::arrow_data_type(),
+            false,
+        ));
+        column_values.push(
+            self.table
+                .column_by_name(Self::TIME_COLUMN_NAME)
+                .expect("The time column must exist")
+                .clone(),
+        );
+
+        // copy remaining attribute data
+        for (column_name, column_type) in &self.types {
+            columns.push(arrow::datatypes::Field::new(
+                &column_name,
+                column_type.arrow_data_type(),
+                column_type.nullable(),
+            ));
+            column_values.push(
+                self.table
+                    .column_by_name(&column_name)
+                    .expect("The attribute column must exist")
+                    .clone(),
+            );
+        }
+
+        Ok(Self::new_from_internals(
+            struct_array_from_data(columns, column_values, self.table.len()),
+            self.types.clone(),
+        ))
     }
 }
 
@@ -477,5 +603,79 @@ mod tests {
             ]
         );
         assert!(geometry_iter.next().is_none());
+    }
+
+    #[test]
+    fn reproject_multi_lines_epsg4326_epsg900913_collection() {
+        use crate::operations::reproject::{CoordinateProjection, CoordinateProjector};
+        use crate::spatial_reference::{SpatialReference, SpatialReferenceAuthority};
+
+        use crate::operations::reproject::tests::{
+            COLOGNE_EPSG_4326, COLOGNE_EPSG_900_913, HAMBURG_EPSG_4326, HAMBURG_EPSG_900_913,
+            MARBURG_EPSG_4326, MARBURG_EPSG_900_913,
+        };
+
+        let from = SpatialReference::epsg_4326();
+        let to = SpatialReference::new(SpatialReferenceAuthority::Epsg, 900_913);
+        let projector = CoordinateProjector::from_known_srs(from, to).unwrap();
+
+        let mut builder = MultiLineStringCollection::builder().finish_header();
+
+        builder
+            .push_geometry(
+                MultiLineString::new(vec![vec![MARBURG_EPSG_4326, HAMBURG_EPSG_4326]]).unwrap(),
+            )
+            .unwrap();
+        builder
+            .push_geometry(
+                MultiLineString::new(vec![
+                    vec![COLOGNE_EPSG_4326, MARBURG_EPSG_4326, HAMBURG_EPSG_4326],
+                    vec![HAMBURG_EPSG_4326, COLOGNE_EPSG_4326],
+                ])
+                .unwrap(),
+            )
+            .unwrap();
+
+        for _ in 0..2 {
+            builder.push_time_interval(TimeInterval::default()).unwrap();
+
+            builder.finish_row();
+        }
+
+        let collection = builder.build().unwrap();
+
+        let mut builder = MultiLineStringCollection::builder().finish_header();
+
+        builder
+            .push_geometry(
+                MultiLineString::new(vec![vec![MARBURG_EPSG_900_913, HAMBURG_EPSG_900_913]])
+                    .unwrap(),
+            )
+            .unwrap();
+        builder
+            .push_geometry(
+                MultiLineString::new(vec![
+                    vec![
+                        COLOGNE_EPSG_900_913,
+                        MARBURG_EPSG_900_913,
+                        HAMBURG_EPSG_900_913,
+                    ],
+                    vec![HAMBURG_EPSG_900_913, COLOGNE_EPSG_900_913],
+                ])
+                .unwrap(),
+            )
+            .unwrap();
+
+        for _ in 0..2 {
+            builder.push_time_interval(TimeInterval::default()).unwrap();
+
+            builder.finish_row();
+        }
+
+        let expected_collection = builder.build().unwrap();
+
+        let proj_collection = collection.reproject(&projector).unwrap();
+
+        assert_eq!(proj_collection, expected_collection)
     }
 }

--- a/datatypes/src/collections/multi_line_string_collection.rs
+++ b/datatypes/src/collections/multi_line_string_collection.rs
@@ -610,7 +610,7 @@ mod tests {
         use crate::operations::reproject::{CoordinateProjection, CoordinateProjector};
         use crate::spatial_reference::{SpatialReference, SpatialReferenceAuthority};
 
-        use crate::operations::reproject::tests::{
+        use crate::util::well_known_data::{
             COLOGNE_EPSG_4326, COLOGNE_EPSG_900_913, HAMBURG_EPSG_4326, HAMBURG_EPSG_900_913,
             MARBURG_EPSG_4326, MARBURG_EPSG_900_913,
         };

--- a/datatypes/src/collections/multi_point_collection.rs
+++ b/datatypes/src/collections/multi_point_collection.rs
@@ -1158,7 +1158,7 @@ mod tests {
         use crate::operations::reproject::{CoordinateProjection, CoordinateProjector};
         use crate::spatial_reference::{SpatialReference, SpatialReferenceAuthority};
 
-        use crate::operations::reproject::tests::{
+        use crate::util::well_known_data::{
             COLOGNE_EPSG_4326, COLOGNE_EPSG_900_913, HAMBURG_EPSG_4326, HAMBURG_EPSG_900_913,
             MARBURG_EPSG_4326, MARBURG_EPSG_900_913,
         };
@@ -1210,7 +1210,7 @@ mod tests {
         use crate::operations::reproject::{CoordinateProjection, CoordinateProjector};
         use crate::spatial_reference::{SpatialReference, SpatialReferenceAuthority};
 
-        use crate::operations::reproject::tests::{
+        use crate::util::well_known_data::{
             COLOGNE_EPSG_4326, COLOGNE_EPSG_900_913, HAMBURG_EPSG_4326, HAMBURG_EPSG_900_913,
             MARBURG_EPSG_4326, MARBURG_EPSG_900_913,
         };

--- a/datatypes/src/collections/multi_point_collection.rs
+++ b/datatypes/src/collections/multi_point_collection.rs
@@ -187,7 +187,7 @@ impl ReplaceRawArrayCoords for MultiPointCollection {
         let geometries: &ListArray = downcast_array(array_ref);
         let offset_array = geometries.data();
         let offsets_buffer = &offset_array.buffers()[0];
-        let num_features = (offsets_buffer.len() / std::mem::size_of::<i32>()) - 1;
+        let num_features = offset_array.len();
 
         let num_coords = new_coords.len() / std::mem::size_of::<Coordinate2D>();
         let num_floats = num_coords * 2;

--- a/datatypes/src/collections/multi_polygon_collection.rs
+++ b/datatypes/src/collections/multi_polygon_collection.rs
@@ -828,7 +828,7 @@ mod tests {
         use crate::operations::reproject::{CoordinateProjection, CoordinateProjector};
         use crate::spatial_reference::{SpatialReference, SpatialReferenceAuthority};
 
-        use crate::operations::reproject::tests::{
+        use crate::util::well_known_data::{
             COLOGNE_EPSG_4326, COLOGNE_EPSG_900_913, HAMBURG_EPSG_4326, HAMBURG_EPSG_900_913,
             MARBURG_EPSG_4326, MARBURG_EPSG_900_913,
         };

--- a/datatypes/src/collections/multi_polygon_collection.rs
+++ b/datatypes/src/collections/multi_polygon_collection.rs
@@ -749,6 +749,7 @@ mod tests {
     fn reproject_multi_lines_epsg4326_epsg900913_collection() {
         use crate::operations::reproject::Reproject;
         use crate::operations::reproject::{CoordinateProjection, CoordinateProjector};
+        use crate::primitives::FeatureData;
         use crate::spatial_reference::{SpatialReference, SpatialReferenceAuthority};
 
         use crate::util::well_known_data::{
@@ -760,10 +761,8 @@ mod tests {
         let to = SpatialReference::new(SpatialReferenceAuthority::Epsg, 900_913);
         let projector = CoordinateProjector::from_known_srs(from, to).unwrap();
 
-        let mut builder = MultiPolygonCollection::builder().finish_header();
-
-        builder
-            .push_geometry(
+        let collection = MultiPolygonCollection::from_slices(
+            &[
                 MultiPolygon::new(vec![
                     vec![vec![
                         HAMBURG_EPSG_4326,
@@ -779,10 +778,6 @@ mod tests {
                     ]],
                 ])
                 .unwrap(),
-            )
-            .unwrap();
-        builder
-            .push_geometry(
                 MultiPolygon::new(vec![vec![vec![
                     MARBURG_EPSG_4326,
                     COLOGNE_EPSG_4326,
@@ -790,21 +785,14 @@ mod tests {
                     MARBURG_EPSG_4326,
                 ]]])
                 .unwrap(),
-            )
-            .unwrap();
+            ],
+            &[TimeInterval::default(), TimeInterval::default()],
+            &[("A", FeatureData::Decimal(vec![1, 2]))],
+        )
+        .unwrap();
 
-        for _ in 0..2 {
-            builder.push_time_interval(TimeInterval::default()).unwrap();
-
-            builder.finish_row();
-        }
-
-        let collection = builder.build().unwrap();
-
-        let mut builder = MultiPolygonCollection::builder().finish_header();
-
-        builder
-            .push_geometry(
+        let expected_collection = MultiPolygonCollection::from_slices(
+            &[
                 MultiPolygon::new(vec![
                     vec![vec![
                         HAMBURG_EPSG_900_913,
@@ -820,10 +808,6 @@ mod tests {
                     ]],
                 ])
                 .unwrap(),
-            )
-            .unwrap();
-        builder
-            .push_geometry(
                 MultiPolygon::new(vec![vec![vec![
                     MARBURG_EPSG_900_913,
                     COLOGNE_EPSG_900_913,
@@ -831,16 +815,11 @@ mod tests {
                     MARBURG_EPSG_900_913,
                 ]]])
                 .unwrap(),
-            )
-            .unwrap();
-
-        for _ in 0..2 {
-            builder.push_time_interval(TimeInterval::default()).unwrap();
-
-            builder.finish_row();
-        }
-
-        let expected_collection = builder.build().unwrap();
+            ],
+            &[TimeInterval::default(), TimeInterval::default()],
+            &[("A", FeatureData::Decimal(vec![1, 2]))],
+        )
+        .unwrap();
 
         let proj_collection = collection.reproject(&projector).unwrap();
 

--- a/datatypes/src/operations/reproject.rs
+++ b/datatypes/src/operations/reproject.rs
@@ -224,50 +224,13 @@ where
 #[cfg(test)]
 pub(crate) mod tests {
     use crate::spatial_reference::SpatialReferenceAuthority;
+    use crate::util::well_known_data::{
+        COLOGNE_EPSG_4326, COLOGNE_EPSG_900_913, HAMBURG_EPSG_4326, HAMBURG_EPSG_900_913,
+        MARBURG_EPSG_4326, MARBURG_EPSG_900_913,
+    };
     use float_cmp::approx_eq;
 
     use super::*;
-
-    // coordinates used for the tests in EPSG:4326
-    // and reprojected with proj cs2cs to EPSG:900913
-    //
-    // cs2cs -d 10  EPSG:4326 EPSG:900913
-    // 50.8021728 8.7667933
-    // 975914.9660458824       6586374.7028446598 0.0000000000
-    // 50.937531 6.9602786
-    // 774814.6695313191       6610251.1099264193 0.0000000000
-    // 53.565278 10.001389
-    // 1113349.5307054475      7088251.2962248782 0.0000000000
-
-    pub const MARBURG_EPSG_4326: Coordinate2D = Coordinate2D {
-        x: 8.766_793_3,
-        y: 50.802_172_8,
-    };
-
-    pub const MARBURG_EPSG_900_913: Coordinate2D = Coordinate2D {
-        x: 975_914.966_045_882_4,
-        y: 6_586_374.702_844_66,
-    };
-
-    pub const COLOGNE_EPSG_4326: Coordinate2D = Coordinate2D {
-        x: 6.960_278_6,
-        y: 50.937_531,
-    };
-
-    pub const COLOGNE_EPSG_900_913: Coordinate2D = Coordinate2D {
-        x: 774_814.669_531_319,
-        y: 6_610_251.109_926_419,
-    };
-
-    pub const HAMBURG_EPSG_4326: Coordinate2D = Coordinate2D {
-        x: 10.001_389,
-        y: 53.565_278,
-    };
-
-    pub const HAMBURG_EPSG_900_913: Coordinate2D = Coordinate2D {
-        x: 1_113_349.530_705_447_5,
-        y: 7_088_251.296_224_878,
-    };
 
     #[test]
     fn new_proj() {

--- a/datatypes/src/operations/reproject.rs
+++ b/datatypes/src/operations/reproject.rs
@@ -31,7 +31,6 @@ pub struct CoordinateProjector {
     p: Proj,
 }
 
-// TODO: move Proj impl into a separate module?
 impl CoordinateProjection for CoordinateProjector {
     fn from_known_srs(from: SpatialReference, to: SpatialReference) -> Result<Self> {
         let p = Proj::new_known_crs(&from.to_string(), &to.to_string(), None)

--- a/datatypes/src/operations/reproject.rs
+++ b/datatypes/src/operations/reproject.rs
@@ -222,7 +222,7 @@ where
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
+mod tests {
     use crate::spatial_reference::SpatialReferenceAuthority;
     use crate::util::well_known_data::{
         COLOGNE_EPSG_4326, COLOGNE_EPSG_900_913, HAMBURG_EPSG_4326, HAMBURG_EPSG_900_913,

--- a/datatypes/src/operations/reproject.rs
+++ b/datatypes/src/operations/reproject.rs
@@ -191,7 +191,7 @@ where
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use crate::spatial_reference::SpatialReferenceAuthority;
     use float_cmp::approx_eq;
 
@@ -208,33 +208,33 @@ mod tests {
     // 53.565278 10.001389
     // 1113349.5307054475      7088251.2962248782 0.0000000000
 
-    const MARBURG_EPSG_4326: Coordinate2D = Coordinate2D {
+    pub const MARBURG_EPSG_4326: Coordinate2D = Coordinate2D {
         x: 8.766_793_3,
         y: 50.802_172_8,
     };
 
-    const MARBURG_EPSG_900_913: Coordinate2D = Coordinate2D {
-        x: 975_914.966_045_882,
-        y: 6_586_374.702_844_659,
+    pub const MARBURG_EPSG_900_913: Coordinate2D = Coordinate2D {
+        x: 975_914.966_045_882_4,
+        y: 6_586_374.702_844_66,
     };
 
-    const COLOGNE_EPSG_4326: Coordinate2D = Coordinate2D {
+    pub const COLOGNE_EPSG_4326: Coordinate2D = Coordinate2D {
         x: 6.960_278_6,
         y: 50.937_531,
     };
 
-    const COLOGNE_EPSG_900_913: Coordinate2D = Coordinate2D {
+    pub const COLOGNE_EPSG_900_913: Coordinate2D = Coordinate2D {
         x: 774_814.669_531_319,
         y: 6_610_251.109_926_419,
     };
 
-    const HAMBURG_EPSG_4326: Coordinate2D = Coordinate2D {
+    pub const HAMBURG_EPSG_4326: Coordinate2D = Coordinate2D {
         x: 10.001_389,
         y: 53.565_278,
     };
 
-    const HAMBURG_EPSG_900_913: Coordinate2D = Coordinate2D {
-        x: 1_113_349.530_705_447,
+    pub const HAMBURG_EPSG_900_913: Coordinate2D = Coordinate2D {
+        x: 1_113_349.530_705_447_5,
         y: 7_088_251.296_224_878,
     };
 

--- a/datatypes/src/operations/reproject.rs
+++ b/datatypes/src/operations/reproject.rs
@@ -15,14 +15,12 @@ pub trait CoordinateProjection {
     fn from_known_srs(from: SpatialReference, to: SpatialReference) -> Result<Self>
     where
         Self: Sized;
+    /// project a single coord
     fn project_coordinate(&self, c: Coordinate2D) -> Result<Coordinate2D>;
 
-    // TODO: add for performance
-    // fn project_coordinate_slice_inplace(&self, coords: &mut [Coordinate2D]) -> Result<&mut [Coordinate2D]>;
-    fn project_coordinate_slice_copy<A: AsRef<[Coordinate2D]>>(
-        &self,
-        coords: A,
-    ) -> Result<Vec<Coordinate2D>>;
+    /// project a set of coords
+    fn project_coordinates<A: AsRef<[Coordinate2D]>>(&self, coords: A)
+        -> Result<Vec<Coordinate2D>>;
 }
 
 pub struct CoordinateProjector {
@@ -42,7 +40,7 @@ impl CoordinateProjection for CoordinateProjector {
         self.p.convert(c).map_err(Into::into)
     }
 
-    fn project_coordinate_slice_copy<A: AsRef<[Coordinate2D]>>(
+    fn project_coordinates<A: AsRef<[Coordinate2D]>>(
         &self,
         coords: A,
     ) -> Result<Vec<Coordinate2D>> {
@@ -94,7 +92,7 @@ where
 {
     type Out = MultiPoint;
     fn reproject(&self, projector: &P) -> Result<MultiPoint> {
-        let ps: Result<Vec<Coordinate2D>> = projector.project_coordinate_slice_copy(self.points());
+        let ps: Result<Vec<Coordinate2D>> = projector.project_coordinates(self.points());
         ps.and_then(MultiPoint::new)
     }
 }
@@ -105,7 +103,7 @@ where
 {
     type Out = MultiPoint;
     fn reproject(&self, projector: &P) -> Result<MultiPoint> {
-        let ps: Result<Vec<Coordinate2D>> = projector.project_coordinate_slice_copy(self.points());
+        let ps: Result<Vec<Coordinate2D>> = projector.project_coordinates(self.points());
         ps.and_then(MultiPoint::new)
     }
 }
@@ -133,7 +131,7 @@ where
         let ls: Result<Vec<Vec<Coordinate2D>>> = self
             .lines()
             .iter()
-            .map(|line| projector.project_coordinate_slice_copy(line))
+            .map(|line| projector.project_coordinates(line))
             .collect();
         ls.and_then(MultiLineString::new)
     }
@@ -148,7 +146,7 @@ where
         let ls: Result<Vec<Vec<Coordinate2D>>> = self
             .lines()
             .iter()
-            .map(|line| projector.project_coordinate_slice_copy(line))
+            .map(|line| projector.project_coordinates(line))
             .collect();
         ls.and_then(MultiLineString::new)
     }
@@ -165,7 +163,7 @@ where
             .iter()
             .map(|poly| {
                 poly.iter()
-                    .map(|ring| projector.project_coordinate_slice_copy(ring))
+                    .map(|ring| projector.project_coordinates(ring))
                     .collect()
             })
             .collect();
@@ -184,7 +182,7 @@ where
             .iter()
             .map(|poly| {
                 poly.iter()
-                    .map(|ring| projector.project_coordinate_slice_copy(ring))
+                    .map(|ring| projector.project_coordinates(ring))
                     .collect()
             })
             .collect();

--- a/datatypes/src/primitives/coordinate.rs
+++ b/datatypes/src/primitives/coordinate.rs
@@ -5,6 +5,7 @@ use arrow::error::ArrowError;
 use ocl::OclPrm;
 #[cfg(feature = "postgres")]
 use postgres_types::{FromSql, ToSql};
+use proj::Coord;
 use serde::{Deserialize, Serialize};
 use std::{
     fmt,
@@ -148,6 +149,20 @@ impl From<Coordinate2D> for geo::Coordinate<f64> {
 impl From<&Coordinate2D> for geo::Coordinate<f64> {
     fn from(coordinate: &Coordinate2D) -> geo::Coordinate<f64> {
         geo::Coordinate::from((coordinate.x, coordinate.y))
+    }
+}
+
+impl Coord<f64> for Coordinate2D {
+    fn x(&self) -> f64 {
+        self.x
+    }
+
+    fn y(&self) -> f64 {
+        self.y
+    }
+
+    fn from_xy(x: f64, y: f64) -> Self {
+        Coordinate2D::new(x, y)
     }
 }
 

--- a/datatypes/src/primitives/multi_point.rs
+++ b/datatypes/src/primitives/multi_point.rs
@@ -40,13 +40,10 @@ impl MultiPoint {
         M: TryInto<MultiPoint, Error = E>,
         E: Into<crate::error::Error>,
     {
-        let mut multi_points = Vec::with_capacity(raw_multi_points.len());
-
-        for multi_point in raw_multi_points {
-            multi_points.push(multi_point.try_into().map_err(Into::into)?);
-        }
-
-        Ok(multi_points)
+        raw_multi_points
+            .into_iter()
+            .map(|m| m.try_into().map_err(Into::into))
+            .collect()
     }
 }
 

--- a/datatypes/src/util/mod.rs
+++ b/datatypes/src/util/mod.rs
@@ -1,6 +1,7 @@
 pub mod arrow;
 pub mod helpers;
 mod identifiers;
+pub mod well_known_data;
 
 pub use self::identifiers::Identifier;
 pub mod ranges;

--- a/datatypes/src/util/well_known_data.rs
+++ b/datatypes/src/util/well_known_data.rs
@@ -1,0 +1,42 @@
+use crate::primitives::Coordinate2D;
+
+// coordinates used for the tests in EPSG:4326
+// and reprojected with proj cs2cs to EPSG:900913
+//
+// cs2cs -d 10  EPSG:4326 EPSG:900913
+// 50.8021728 8.7667933
+// 975914.9660458824       6586374.7028446598 0.0000000000
+// 50.937531 6.9602786
+// 774814.6695313191       6610251.1099264193 0.0000000000
+// 53.565278 10.001389
+// 1113349.5307054475      7088251.2962248782 0.0000000000
+
+pub const MARBURG_EPSG_4326: Coordinate2D = Coordinate2D {
+    x: 8.766_793_3,
+    y: 50.802_172_8,
+};
+
+pub const MARBURG_EPSG_900_913: Coordinate2D = Coordinate2D {
+    x: 975_914.966_045_882_4,
+    y: 6_586_374.702_844_66,
+};
+
+pub const COLOGNE_EPSG_4326: Coordinate2D = Coordinate2D {
+    x: 6.960_278_6,
+    y: 50.937_531,
+};
+
+pub const COLOGNE_EPSG_900_913: Coordinate2D = Coordinate2D {
+    x: 774_814.669_531_319,
+    y: 6_610_251.109_926_419,
+};
+
+pub const HAMBURG_EPSG_4326: Coordinate2D = Coordinate2D {
+    x: 10.001_389,
+    y: 53.565_278,
+};
+
+pub const HAMBURG_EPSG_900_913: Coordinate2D = Coordinate2D {
+    x: 1_113_349.530_705_447_5,
+    y: 7_088_251.296_224_878,
+};

--- a/operators/src/processing/map_query.rs
+++ b/operators/src/processing/map_query.rs
@@ -2,7 +2,7 @@ use crate::{engine::QueryProcessor, util::Result};
 
 use crate::engine::{QueryContext, QueryRectangle};
 
-/// This `QueryProcessor` allows to rewrite a query. It does not change the data. Results of the chuldren are forwarded.
+/// This `QueryProcessor` allows to rewrite a query. It does not change the data. Results of the children are forwarded.
 pub(crate) struct MapQueryProcessor<S, Q> {
     source: S,
     query_fn: Q,

--- a/operators/src/processing/map_query.rs
+++ b/operators/src/processing/map_query.rs
@@ -2,7 +2,7 @@ use crate::{engine::QueryProcessor, util::Result};
 
 use crate::engine::{QueryContext, QueryRectangle};
 
-/// This QueryProcessor allows to rewrite a query. It does not change the data. Results of the chuldren are forwarded.
+/// This `QueryProcessor` allows to rewrite a query. It does not change the data. Results of the chuldren are forwarded.
 pub(crate) struct MapQueryProcessor<S, Q> {
     source: S,
     query_fn: Q,

--- a/operators/src/processing/map_query.rs
+++ b/operators/src/processing/map_query.rs
@@ -2,6 +2,7 @@ use crate::{engine::QueryProcessor, util::Result};
 
 use crate::engine::{QueryContext, QueryRectangle};
 
+/// This QueryProcessor allows to rewrite a query. It does not change the data. Results of the chuldren are forwarded.
 pub(crate) struct MapQueryProcessor<S, Q> {
     source: S,
     query_fn: Q,

--- a/operators/src/processing/map_query.rs
+++ b/operators/src/processing/map_query.rs
@@ -2,18 +2,18 @@ use crate::{engine::QueryProcessor, util::Result};
 
 use crate::engine::{QueryContext, QueryRectangle};
 
-pub(crate) struct QueryRewriteProcessor<S, Q> {
+pub(crate) struct MapQueryProcessor<S, Q> {
     source: S,
     query_fn: Q,
 }
 
-impl<S, Q> QueryRewriteProcessor<S, Q> {
+impl<S, Q> MapQueryProcessor<S, Q> {
     pub fn new(source: S, query_fn: Q) -> Self {
         Self { source, query_fn }
     }
 }
 
-impl<S, Q> QueryProcessor for QueryRewriteProcessor<S, Q>
+impl<S, Q> QueryProcessor for MapQueryProcessor<S, Q>
 where
     S: QueryProcessor,
     Q: Fn(QueryRectangle) -> QueryRectangle + Sync + Send,

--- a/operators/src/processing/mod.rs
+++ b/operators/src/processing/mod.rs
@@ -1,5 +1,7 @@
 mod column_range_filter;
 mod expression;
 mod point_in_polygon;
+mod query_rewrite;
 mod raster_vector_join;
+mod reprojection;
 mod vector_join;

--- a/operators/src/processing/mod.rs
+++ b/operators/src/processing/mod.rs
@@ -1,7 +1,7 @@
 mod column_range_filter;
 mod expression;
+mod map_query;
 mod point_in_polygon;
-mod query_rewrite;
 mod raster_vector_join;
 mod reprojection;
 mod vector_join;

--- a/operators/src/processing/query_rewrite.rs
+++ b/operators/src/processing/query_rewrite.rs
@@ -1,0 +1,31 @@
+use crate::{engine::QueryProcessor, util::Result};
+
+use crate::engine::{QueryContext, QueryRectangle};
+
+pub(crate) struct QueryRewriteProcessor<S, Q> {
+    source: S,
+    query_fn: Q,
+}
+
+impl<S, Q> QueryRewriteProcessor<S, Q> {
+    pub fn new(source: S, query_fn: Q) -> Self {
+        Self { source, query_fn }
+    }
+}
+
+impl<S, Q> QueryProcessor for QueryRewriteProcessor<S, Q>
+where
+    S: QueryProcessor,
+    Q: Fn(QueryRectangle) -> QueryRectangle + Sync + Send,
+{
+    type Output = S::Output;
+
+    fn query<'a>(
+        &'a self,
+        query: QueryRectangle,
+        ctx: &'a dyn QueryContext,
+    ) -> futures::stream::BoxStream<'a, Result<Self::Output>> {
+        let rewritten_query = (self.query_fn)(query); // TODO: error checking
+        self.source.query(rewritten_query, ctx)
+    }
+}

--- a/operators/src/processing/reprojection.rs
+++ b/operators/src/processing/reprojection.rs
@@ -18,7 +18,7 @@ use crate::{
     util::Result,
 };
 
-use super::query_rewrite::QueryRewriteProcessor;
+use super::map_query::MapQueryProcessor;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ReprojectionParams {
@@ -83,7 +83,7 @@ impl InitializedOperator<VectorResultDescriptor, TypedVectorQueryProcessor>
         match self.vector_sources[0].query_processor()? {
             // TODO: use macro for that
             TypedVectorQueryProcessor::Data(source) => Ok(TypedVectorQueryProcessor::Data(
-                QueryRewriteProcessor::new(source, move |query| {
+                MapQueryProcessor::new(source, move |query| {
                     query_rewrite_fn(query, state.0, state.1)
                 })
                 .boxed(),
@@ -142,7 +142,7 @@ fn query_rewrite_fn(
 impl<Q, G> VectorQueryProcessor for ReprojectionProcessor<Q, G>
 where
     Q: VectorQueryProcessor<VectorType = G>,
-    G: 'static + Reproject<CoordinateProjector> + Sync + Send,
+    G: Reproject<CoordinateProjector> + Sync + Send,
 {
     type VectorType = G::Out;
 
@@ -171,45 +171,75 @@ where
 
 #[cfg(test)]
 mod tests {
+
+    use geoengine_datatypes::{
+        collections::{MultiLineStringCollection, MultiPointCollection, MultiPolygonCollection},
+        primitives::{
+            BoundingBox2D, MultiLineString, MultiPoint, MultiPolygon, SpatialResolution,
+            TimeInterval,
+        },
+        spatial_reference::SpatialReferenceAuthority,
+        util::well_known_data::{
+            COLOGNE_EPSG_4326, COLOGNE_EPSG_900_913, HAMBURG_EPSG_4326, HAMBURG_EPSG_900_913,
+            MARBURG_EPSG_4326, MARBURG_EPSG_900_913,
+        },
+    };
+
+    use crate::engine::{MockExecutionContext, MockQueryContext, QueryProcessor};
+    use crate::mock::MockFeatureCollectionSource;
+    use futures::StreamExt;
+
     use super::*;
 
-    #[test]
     #[tokio::test]
     async fn multi_point() -> Result<()> {
         let points = MultiPointCollection::from_data(
-            MultiPoint::many(vec![(0.001, 0.1), (1.0, 1.1), (2.0, 3.1)]).unwrap(),
+            MultiPoint::many(vec![
+                MARBURG_EPSG_4326,
+                COLOGNE_EPSG_4326,
+                HAMBURG_EPSG_4326,
+            ])
+            .unwrap(),
+            vec![TimeInterval::new_unchecked(0, 1); 3],
+            Default::default(),
+        )?;
+
+        let projected_points = MultiPointCollection::from_data(
+            MultiPoint::many(vec![
+                MARBURG_EPSG_900_913,
+                COLOGNE_EPSG_900_913,
+                HAMBURG_EPSG_900_913,
+            ])
+            .unwrap(),
             vec![TimeInterval::new_unchecked(0, 1); 3],
             Default::default(),
         )?;
 
         let point_source = MockFeatureCollectionSource::single(points.clone()).boxed();
 
-        let polygon_source =
-            MockFeatureCollectionSource::single(MultiPolygonCollection::from_data(
-                vec![MultiPolygon::new(vec![vec![vec![
-                    (0.0, 0.0).into(),
-                    (10.0, 0.0).into(),
-                    (10.0, 10.0).into(),
-                    (0.0, 10.0).into(),
-                    (0.0, 0.0).into(),
-                ]]])?],
-                vec![TimeInterval::new_unchecked(0, 1); 1],
-                Default::default(),
-            )?)
-            .boxed();
+        let target_spatial_reference =
+            SpatialReference::new(SpatialReferenceAuthority::Epsg, 900913);
 
-        let operator = PointInPolygonFilter {
-            vector_sources: vec![point_source, polygon_source],
+        let initialized_operator = Reprojection {
+            vector_sources: vec![point_source],
             raster_sources: vec![],
-            params: (),
+            params: ReprojectionParams {
+                target_spatial_reference,
+            },
         }
         .boxed()
         .initialize(&MockExecutionContext::default())?;
 
-        let query_processor = operator.query_processor()?.multi_point().unwrap();
+        let query_processor = initialized_operator.query_processor()?;
+
+        let query_processor = query_processor.multi_point().unwrap();
 
         let query_rectangle = QueryRectangle {
-            bbox: BoundingBox2D::new((0., 0.).into(), (10., 10.).into()).unwrap(),
+            bbox: BoundingBox2D::new(
+                (COLOGNE_EPSG_4326.x, MARBURG_EPSG_4326.y).into(),
+                (MARBURG_EPSG_4326.x, HAMBURG_EPSG_4326.y).into(),
+            )
+            .unwrap(),
             time_interval: TimeInterval::default(),
             spatial_resolution: SpatialResolution::zero_point_one(),
         };
@@ -224,7 +254,145 @@ mod tests {
 
         assert_eq!(result.len(), 1);
 
-        assert_eq!(result[0], points);
+        assert_eq!(result[0], projected_points);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn multi_lines() -> Result<()> {
+        let lines = MultiLineStringCollection::from_data(
+            vec![MultiLineString::new(vec![vec![
+                MARBURG_EPSG_4326,
+                COLOGNE_EPSG_4326,
+                HAMBURG_EPSG_4326,
+            ]])
+            .unwrap()],
+            vec![TimeInterval::new_unchecked(0, 1); 1],
+            Default::default(),
+        )?;
+
+        let projected_lines = MultiLineStringCollection::from_data(
+            vec![MultiLineString::new(vec![vec![
+                MARBURG_EPSG_900_913,
+                COLOGNE_EPSG_900_913,
+                HAMBURG_EPSG_900_913,
+            ]])
+            .unwrap()],
+            vec![TimeInterval::new_unchecked(0, 1); 1],
+            Default::default(),
+        )?;
+
+        let lines_source = MockFeatureCollectionSource::single(lines.clone()).boxed();
+
+        let target_spatial_reference =
+            SpatialReference::new(SpatialReferenceAuthority::Epsg, 900913);
+
+        let initialized_operator = Reprojection {
+            vector_sources: vec![lines_source],
+            raster_sources: vec![],
+            params: ReprojectionParams {
+                target_spatial_reference,
+            },
+        }
+        .boxed()
+        .initialize(&MockExecutionContext::default())?;
+
+        let query_processor = initialized_operator.query_processor()?;
+
+        let query_processor = query_processor.multi_line_string().unwrap();
+
+        let query_rectangle = QueryRectangle {
+            bbox: BoundingBox2D::new(
+                (COLOGNE_EPSG_4326.x, MARBURG_EPSG_4326.y).into(),
+                (MARBURG_EPSG_4326.x, HAMBURG_EPSG_4326.y).into(),
+            )
+            .unwrap(),
+            time_interval: TimeInterval::default(),
+            spatial_resolution: SpatialResolution::zero_point_one(),
+        };
+        let ctx = MockQueryContext::new(usize::MAX);
+
+        let query = query_processor.query(query_rectangle, &ctx);
+
+        let result = query
+            .map(Result::unwrap)
+            .collect::<Vec<MultiLineStringCollection>>()
+            .await;
+
+        assert_eq!(result.len(), 1);
+
+        assert_eq!(result[0], projected_lines);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn multi_polygons() -> Result<()> {
+        let polygons = MultiPolygonCollection::from_data(
+            vec![MultiPolygon::new(vec![vec![vec![
+                MARBURG_EPSG_4326,
+                COLOGNE_EPSG_4326,
+                HAMBURG_EPSG_4326,
+                MARBURG_EPSG_4326,
+            ]]])
+            .unwrap()],
+            vec![TimeInterval::new_unchecked(0, 1); 1],
+            Default::default(),
+        )?;
+
+        let projected_polygons = MultiPolygonCollection::from_data(
+            vec![MultiPolygon::new(vec![vec![vec![
+                MARBURG_EPSG_900_913,
+                COLOGNE_EPSG_900_913,
+                HAMBURG_EPSG_900_913,
+                MARBURG_EPSG_900_913,
+            ]]])
+            .unwrap()],
+            vec![TimeInterval::new_unchecked(0, 1); 1],
+            Default::default(),
+        )?;
+
+        let polygon_source = MockFeatureCollectionSource::single(polygons.clone()).boxed();
+
+        let target_spatial_reference =
+            SpatialReference::new(SpatialReferenceAuthority::Epsg, 900913);
+
+        let initialized_operator = Reprojection {
+            vector_sources: vec![polygon_source],
+            raster_sources: vec![],
+            params: ReprojectionParams {
+                target_spatial_reference,
+            },
+        }
+        .boxed()
+        .initialize(&MockExecutionContext::default())?;
+
+        let query_processor = initialized_operator.query_processor()?;
+
+        let query_processor = query_processor.multi_polygon().unwrap();
+
+        let query_rectangle = QueryRectangle {
+            bbox: BoundingBox2D::new(
+                (COLOGNE_EPSG_4326.x, MARBURG_EPSG_4326.y).into(),
+                (MARBURG_EPSG_4326.x, HAMBURG_EPSG_4326.y).into(),
+            )
+            .unwrap(),
+            time_interval: TimeInterval::default(),
+            spatial_resolution: SpatialResolution::zero_point_one(),
+        };
+        let ctx = MockQueryContext::new(usize::MAX);
+
+        let query = query_processor.query(query_rectangle, &ctx);
+
+        let result = query
+            .map(Result::unwrap)
+            .collect::<Vec<MultiPolygonCollection>>()
+            .await;
+
+        assert_eq!(result.len(), 1);
+
+        assert_eq!(result[0], projected_polygons);
 
         Ok(())
     }

--- a/operators/src/processing/reprojection.rs
+++ b/operators/src/processing/reprojection.rs
@@ -218,7 +218,7 @@ mod tests {
         let point_source = MockFeatureCollectionSource::single(points.clone()).boxed();
 
         let target_spatial_reference =
-            SpatialReference::new(SpatialReferenceAuthority::Epsg, 900913);
+            SpatialReference::new(SpatialReferenceAuthority::Epsg, 900_913);
 
         let initialized_operator = Reprojection {
             vector_sources: vec![point_source],
@@ -286,7 +286,7 @@ mod tests {
         let lines_source = MockFeatureCollectionSource::single(lines.clone()).boxed();
 
         let target_spatial_reference =
-            SpatialReference::new(SpatialReferenceAuthority::Epsg, 900913);
+            SpatialReference::new(SpatialReferenceAuthority::Epsg, 900_913);
 
         let initialized_operator = Reprojection {
             vector_sources: vec![lines_source],
@@ -356,7 +356,7 @@ mod tests {
         let polygon_source = MockFeatureCollectionSource::single(polygons.clone()).boxed();
 
         let target_spatial_reference =
-            SpatialReference::new(SpatialReferenceAuthority::Epsg, 900913);
+            SpatialReference::new(SpatialReferenceAuthority::Epsg, 900_913);
 
         let initialized_operator = Reprojection {
             vector_sources: vec![polygon_source],

--- a/operators/src/processing/reprojection.rs
+++ b/operators/src/processing/reprojection.rs
@@ -107,21 +107,21 @@ impl InitializedOperator<VectorResultDescriptor, TypedVectorQueryProcessor>
     }
 }
 
-struct ReprojectionProcessor<Q, G> {
+struct ReprojectionProcessor<Q, G>
+where
+    Q: VectorQueryProcessor<VectorType = G>,
+{
     source: Q,
     from: SpatialReference,
     to: SpatialReference,
-    geom_type: PhantomData<G>,
 }
 
-impl<Q, G> ReprojectionProcessor<Q, G> {
+impl<Q, G> ReprojectionProcessor<Q, G>
+where
+    Q: VectorQueryProcessor<VectorType = G>,
+{
     pub fn new(source: Q, from: SpatialReference, to: SpatialReference) -> Self {
-        Self {
-            source,
-            from,
-            to,
-            geom_type: PhantomData,
-        }
+        Self { source, from, to }
     }
 }
 

--- a/operators/src/processing/reprojection.rs
+++ b/operators/src/processing/reprojection.rs
@@ -1,0 +1,231 @@
+use std::marker::PhantomData;
+
+use futures::TryStreamExt;
+use geoengine_datatypes::{
+    operations::reproject::{CoordinateProjection, CoordinateProjector, Reproject},
+    spatial_reference::SpatialReference,
+};
+use serde::{Deserialize, Serialize};
+use snafu::ensure;
+
+use crate::{
+    engine::{
+        ExecutionContext, InitializedOperator, InitializedOperatorImpl, InitializedVectorOperator,
+        Operator, QueryContext, QueryRectangle, TypedVectorQueryProcessor, VectorOperator,
+        VectorQueryProcessor, VectorResultDescriptor,
+    },
+    error,
+    util::Result,
+};
+
+use super::query_rewrite::QueryRewriteProcessor;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ReprojectionParams {
+    pub target_spatial_reference: SpatialReference,
+}
+
+pub type Reprojection = Operator<ReprojectionParams>;
+pub type InitializedReprojection =
+    InitializedOperatorImpl<(), VectorResultDescriptor, (SpatialReference, SpatialReference)>;
+
+#[typetag::serde]
+impl VectorOperator for Reprojection {
+    fn initialize(
+        self: Box<Self>,
+        context: &dyn ExecutionContext,
+    ) -> Result<Box<InitializedVectorOperator>> {
+        ensure!(
+            self.vector_sources.len() == 1,
+            error::InvalidNumberOfVectorInputs {
+                expected: 1..2,
+                found: self.vector_sources.len()
+            }
+        );
+        ensure!(
+            self.raster_sources.is_empty(),
+            error::InvalidNumberOfRasterInputs {
+                expected: 0..1,
+                found: self.raster_sources.len()
+            }
+        );
+
+        let initialized_vector_sources = self
+            .vector_sources
+            .into_iter()
+            .map(|o| o.initialize(context))
+            .collect::<Result<Vec<Box<InitializedVectorOperator>>>>()?;
+
+        let in_desc: &VectorResultDescriptor = initialized_vector_sources[0].result_descriptor();
+        let out_desc = VectorResultDescriptor {
+            spatial_reference: self.params.target_spatial_reference.into(),
+            data_type: in_desc.data_type,
+            columns: in_desc.columns.clone(),
+        };
+
+        let state = (
+            Option::from(in_desc.spatial_reference).unwrap(),
+            self.params.target_spatial_reference,
+        );
+
+        Ok(
+            InitializedReprojection::new((), out_desc, vec![], initialized_vector_sources, state)
+                .boxed(),
+        )
+    }
+}
+
+impl InitializedOperator<VectorResultDescriptor, TypedVectorQueryProcessor>
+    for InitializedReprojection
+{
+    fn query_processor(&self) -> Result<TypedVectorQueryProcessor> {
+        let state = self.state;
+        match self.vector_sources[0].query_processor()? {
+            // TODO: use macro for that
+            TypedVectorQueryProcessor::Data(source) => Ok(TypedVectorQueryProcessor::Data(
+                QueryRewriteProcessor::new(source, move |query| {
+                    query_rewrite_fn(query, state.0, state.1)
+                })
+                .boxed(),
+            )),
+            TypedVectorQueryProcessor::MultiPoint(source) => {
+                Ok(TypedVectorQueryProcessor::MultiPoint(
+                    ReprojectionProcessor::new(source, self.state.0, self.state.1).boxed(),
+                ))
+            }
+            TypedVectorQueryProcessor::MultiLineString(source) => {
+                Ok(TypedVectorQueryProcessor::MultiLineString(
+                    ReprojectionProcessor::new(source, self.state.0, self.state.1).boxed(),
+                ))
+            }
+            TypedVectorQueryProcessor::MultiPolygon(source) => {
+                Ok(TypedVectorQueryProcessor::MultiPolygon(
+                    ReprojectionProcessor::new(source, self.state.0, self.state.1).boxed(),
+                ))
+            }
+        }
+    }
+}
+
+struct ReprojectionProcessor<Q, G> {
+    source: Q,
+    from: SpatialReference,
+    to: SpatialReference,
+    geom_type: PhantomData<G>,
+}
+
+impl<Q, G> ReprojectionProcessor<Q, G> {
+    pub fn new(source: Q, from: SpatialReference, to: SpatialReference) -> Self {
+        Self {
+            source,
+            from,
+            to,
+            geom_type: PhantomData,
+        }
+    }
+}
+
+/// this method performs the reverse transformation of a query rectangle
+fn query_rewrite_fn(
+    query: QueryRectangle,
+    from: SpatialReference,
+    to: SpatialReference,
+) -> QueryRectangle {
+    let projector = CoordinateProjector::from_known_srs(to, from).unwrap();
+    // TODO: change the resolution...
+    QueryRectangle {
+        bbox: query.bbox.reproject(&projector).unwrap(),
+        ..query
+    }
+}
+
+impl<Q, G> VectorQueryProcessor for ReprojectionProcessor<Q, G>
+where
+    Q: VectorQueryProcessor<VectorType = G>,
+    G: 'static + Reproject<CoordinateProjector> + Sync + Send,
+{
+    type VectorType = G::Out;
+
+    fn vector_query<'a>(
+        &'a self,
+        query: QueryRectangle,
+        ctx: &'a dyn QueryContext,
+    ) -> futures::stream::BoxStream<'a, Result<Self::VectorType>> {
+        let rewritten_query = query_rewrite_fn(query, self.from, self.to);
+
+        Box::pin(
+            self.source
+                .vector_query(rewritten_query, ctx)
+                .map_ok(move |collection| {
+                    collection
+                        .reproject(
+                            CoordinateProjector::from_known_srs(self.from, self.to)
+                                .unwrap()
+                                .as_ref(),
+                        )
+                        .unwrap()
+                }),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[tokio::test]
+    async fn multi_point() -> Result<()> {
+        let points = MultiPointCollection::from_data(
+            MultiPoint::many(vec![(0.001, 0.1), (1.0, 1.1), (2.0, 3.1)]).unwrap(),
+            vec![TimeInterval::new_unchecked(0, 1); 3],
+            Default::default(),
+        )?;
+
+        let point_source = MockFeatureCollectionSource::single(points.clone()).boxed();
+
+        let polygon_source =
+            MockFeatureCollectionSource::single(MultiPolygonCollection::from_data(
+                vec![MultiPolygon::new(vec![vec![vec![
+                    (0.0, 0.0).into(),
+                    (10.0, 0.0).into(),
+                    (10.0, 10.0).into(),
+                    (0.0, 10.0).into(),
+                    (0.0, 0.0).into(),
+                ]]])?],
+                vec![TimeInterval::new_unchecked(0, 1); 1],
+                Default::default(),
+            )?)
+            .boxed();
+
+        let operator = PointInPolygonFilter {
+            vector_sources: vec![point_source, polygon_source],
+            raster_sources: vec![],
+            params: (),
+        }
+        .boxed()
+        .initialize(&MockExecutionContext::default())?;
+
+        let query_processor = operator.query_processor()?.multi_point().unwrap();
+
+        let query_rectangle = QueryRectangle {
+            bbox: BoundingBox2D::new((0., 0.).into(), (10., 10.).into()).unwrap(),
+            time_interval: TimeInterval::default(),
+            spatial_resolution: SpatialResolution::zero_point_one(),
+        };
+        let ctx = MockQueryContext::new(usize::MAX);
+
+        let query = query_processor.query(query_rectangle, &ctx);
+
+        let result = query
+            .map(Result::unwrap)
+            .collect::<Vec<MultiPointCollection>>()
+            .await;
+
+        assert_eq!(result.len(), 1);
+
+        assert_eq!(result[0], points);
+
+        Ok(())
+    }
+}

--- a/operators/src/processing/reprojection.rs
+++ b/operators/src/processing/reprojection.rs
@@ -1,4 +1,4 @@
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use geoengine_datatypes::{
     operations::reproject::{CoordinateProjection, CoordinateProjector, Reproject},
     spatial_reference::SpatialReference,


### PR DESCRIPTION
This PR adds reprojection for FeatureCollections and introduces the Reprojection (Operator/Processor) and a MapQueryProcessor.
We can also replace the ReprojectionProcessor with a MapProcessor which takes a Fn(QueryRectangle> -> QueryRectangle and a Fn(G) -> G where G is the processed type. However, we can do this later. 