### PR TITLE
Box Plots

### DIFF
--- a/datatypes/src/plots/box_plot.rs
+++ b/datatypes/src/plots/box_plot.rs
@@ -1,0 +1,173 @@
+use crate::error;
+use crate::plots::{Plot, PlotData, PlotMetaData};
+use crate::util::Result;
+use serde::{Deserialize, Serialize};
+use snafu::ensure;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BoxPlot {
+    values: Vec<BoxPlotAttribute>,
+}
+
+impl BoxPlot {
+    pub fn new() -> BoxPlot {
+        BoxPlot { values: vec![] }
+    }
+
+    pub fn add_attribute(&mut self, value: BoxPlotAttribute) {
+        self.values.push(value);
+    }
+}
+
+impl Default for BoxPlot {
+    fn default() -> Self {
+        BoxPlot::new()
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BoxPlotAttribute {
+    pub name: String,
+    pub min: f64,
+    pub max: f64,
+    pub median: f64,
+    pub q1: f64,
+    pub q3: f64,
+    pub is_exact: bool,
+}
+
+impl BoxPlotAttribute {
+    pub fn new(
+        name: String,
+        min: f64,
+        max: f64,
+        median: f64,
+        q1: f64,
+        q3: f64,
+        is_exact: bool,
+    ) -> Result<BoxPlotAttribute> {
+        ensure!(
+            !min.is_nan() && !max.is_nan() && !median.is_nan() && !q1.is_nan() && !q3.is_nan(),
+            error::Plot {
+                details: "Box plots must have finite values"
+            }
+        );
+
+        ensure!(
+            min <= q1 && q1 <= median && median <= q3 && q3 <= max,
+            error::Plot {
+                details: format!(
+                    "Illegal box plot values. min: {}, q1: {}, median: {}, q3: {}, max: {}",
+                    min, q1, median, q3, max
+                )
+            }
+        );
+
+        Ok(BoxPlotAttribute {
+            name,
+            min,
+            max,
+            median,
+            q1,
+            q3,
+            is_exact,
+        })
+    }
+}
+
+impl Plot for BoxPlot {
+    fn to_vega_embeddable(&self, _allow_interactions: bool) -> Result<PlotData> {
+        let vega_spec = serde_json::json!({
+            "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+            "width": "container",
+            "height": "container",
+            "data": self,
+            "encoding": {"x": {"field": "name", "type": "nominal" }},
+            "layer": [
+              {
+                "mark": {"type": "rule"},
+                "encoding": {
+                  "y": {"field": "min", "type": "quantitative", "scale": {"zero": false} },
+                  "y2": {"field": "max"}
+                }
+              },
+              {
+                "mark": {"type": "bar", "cornerRadius": 5, "width": {"band": 0.75} },
+                "encoding": {
+                  "y": {"field": "q1", "type": "quantitative"},
+                  "y2": {"field": "q3"},
+                  "color": {"field": "name", "type": "nominal"}
+                }
+              },
+              {
+                "mark": {"type": "rect", "color": "white", "width": { "band": 0.75}, "height": 1  },
+                "encoding": {"y": {"field": "median", "type": "quantitative"} }
+              }
+            ],
+            "config": {
+              "axisXDiscrete": { "title": null },
+              "axisYQuantitative": { "title": null },
+              "legend": {
+                "disable": true
+              }
+            }
+        });
+
+        Ok(PlotData {
+            vega_string: vega_spec.to_string(),
+            metadata: PlotMetaData::None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::plots::box_plot::BoxPlotAttribute;
+    use crate::plots::BoxPlot;
+
+    #[test]
+    fn test_ser() {
+        let mut bp = BoxPlot::new();
+        bp.add_attribute(
+            BoxPlotAttribute::new("A1".to_string(), 12.0, 83.0, 35.0, 20.0, 55.0, true).unwrap(),
+        );
+
+        let ser = serde_json::to_string(&bp).unwrap();
+
+        let expected = serde_json::json!({
+            "values": [
+                { "name": "A1", "min": 12.0, "max": 83.0, "median" : 35.0, "q1": 20.0, "q3": 55.0, "isExact": true }
+            ]
+        });
+
+        assert_eq!(expected.to_string(), ser);
+    }
+
+    #[test]
+    fn ok() {
+        assert!(
+            BoxPlotAttribute::new("A1".to_string(), 12.0, 83.0, 35.0, 20.0, 55.0, true).is_ok()
+        );
+        assert!(
+            BoxPlotAttribute::new("A2".to_string(), 35.0, 112.0, 76.0, 55.0, 99.0, false).is_ok()
+        );
+    }
+
+    #[test]
+    fn nan() {
+        assert!(
+            BoxPlotAttribute::new("A1".to_string(), f64::NAN, 83.0, 35.0, 20.0, 55.0, true)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn illegal_order() {
+        assert!(
+            BoxPlotAttribute::new("A1".to_string(), f64::NAN, 35.0, 83.0, 20.0, 55.0, true)
+                .is_err()
+        );
+    }
+}

--- a/datatypes/src/plots/box_plot.rs
+++ b/datatypes/src/plots/box_plot.rs
@@ -4,6 +4,7 @@ use crate::util::Result;
 use serde::{Deserialize, Serialize};
 use snafu::ensure;
 
+/// A box plot consists of multiple boxes (`BoxPlotAttribute`)
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BoxPlot {
@@ -11,10 +12,12 @@ pub struct BoxPlot {
 }
 
 impl BoxPlot {
+    /// Creates a new box plot without any boxes.
     pub fn new() -> BoxPlot {
         BoxPlot { values: vec![] }
     }
 
+    /// Adds a new box/attribute to this box plot.
     pub fn add_attribute(&mut self, value: BoxPlotAttribute) {
         self.values.push(value);
     }
@@ -26,6 +29,7 @@ impl Default for BoxPlot {
     }
 }
 
+/// Represents a single box of a box plot including whiskers
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BoxPlotAttribute {
@@ -51,7 +55,7 @@ impl BoxPlotAttribute {
         ensure!(
             !min.is_nan() && !max.is_nan() && !median.is_nan() && !q1.is_nan() && !q3.is_nan(),
             error::Plot {
-                details: "Box plots must have finite values"
+                details: "NaN values not allowed in box plots."
             }
         );
 

--- a/datatypes/src/plots/mod.rs
+++ b/datatypes/src/plots/mod.rs
@@ -1,8 +1,10 @@
 mod area_line_plot;
+mod box_plot;
 mod histogram;
 mod multi_line_plot;
 
 pub use area_line_plot::AreaLineChart;
+pub use box_plot::{BoxPlot, BoxPlotAttribute};
 pub use histogram::{Histogram, HistogramBuilder};
 pub use multi_line_plot::{DataPoint, MultiLineChart};
 

--- a/operators/src/error.rs
+++ b/operators/src/error.rs
@@ -1,3 +1,4 @@
+use crate::util::statistics::StatisticsError;
 use chrono::ParseError;
 use geoengine_datatypes::dataset::DatasetId;
 use geoengine_datatypes::primitives::FeatureDataType;
@@ -274,6 +275,11 @@ pub enum Error {
         "Raster data sets with a different origin than upper left are currently not supported"
     ))]
     GeoTransformOrigin,
+
+    #[snafu(display("Statistics error: {}", source))]
+    Statistics {
+        source: crate::util::statistics::StatisticsError,
+    },
 }
 
 impl From<geoengine_datatypes::error::Error> for Error {
@@ -325,5 +331,11 @@ impl From<arrow::error::ArrowError> for Error {
 impl From<tokio::task::JoinError> for Error {
     fn from(source: tokio::task::JoinError) -> Self {
         Error::TokioJoin { source }
+    }
+}
+
+impl From<crate::util::statistics::StatisticsError> for Error {
+    fn from(source: StatisticsError) -> Self {
+        Error::Statistics { source }
     }
 }

--- a/operators/src/plot/box_plot.rs
+++ b/operators/src/plot/box_plot.rs
@@ -1,0 +1,810 @@
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+
+use geoengine_datatypes::collections::FeatureCollectionInfos;
+use geoengine_datatypes::plots::{BoxPlotAttribute, Plot, PlotData};
+
+use crate::engine::VectorQueryRectangle;
+use crate::engine::{
+    ExecutionContext, InitializedPlotOperator, InitializedVectorOperator, Operator, PlotOperator,
+    PlotQueryProcessor, PlotResultDescriptor, QueryContext, TypedPlotQueryProcessor,
+    TypedVectorQueryProcessor,
+};
+use crate::engine::{QueryProcessor, SingleVectorSource};
+use crate::error::Error;
+use crate::util::statistics::PSquareQuantileEstimator;
+use crate::util::Result;
+
+pub const BOXPLOT_OPERATOR_NAME: &str = "BoxPlot";
+const EXACT_CALC_BOUND: usize = 10_000;
+
+/// A box plot about vector data attribute values
+pub type BoxPlot = Operator<BoxPlotParams, SingleVectorSource>;
+
+/// The parameter spec for `BoxPlot`
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BoxPlotParams {
+    /// Name of the (numeric) attributes to compute the box plots on.
+    #[serde(default)]
+    pub column_names: Vec<String>,
+    /// Whether to create an interactive output (`false` by default)
+    #[serde(default)]
+    pub interactive: bool,
+}
+
+#[typetag::serde]
+#[async_trait]
+impl PlotOperator for BoxPlot {
+    async fn initialize(
+        self: Box<Self>,
+        context: &dyn ExecutionContext,
+    ) -> Result<Box<dyn InitializedPlotOperator>> {
+        if self.params.column_names.is_empty() {
+            return Err(Error::InvalidOperatorSpec {
+                reason: "BoxPlot requires at least one numeric column ('column_names' parameter)."
+                    .to_string(),
+            });
+        }
+
+        let source = self.sources.vector.initialize(context).await?;
+        for cn in &self.params.column_names {
+            match source.result_descriptor().columns.get(cn.as_str()) {
+                Some(column) if !column.is_numeric() => {
+                    return Err(Error::InvalidOperatorSpec {
+                        reason: format!("Column '{}' is not numeric.", cn),
+                    });
+                }
+                Some(_) => {
+                    // OK
+                }
+                None => {
+                    return Err(Error::ColumnDoesNotExist {
+                        column: cn.to_string(),
+                    });
+                }
+            }
+        }
+        Ok(InitializedBoxPlot::new(PlotResultDescriptor {}, self.params, source).boxed())
+    }
+}
+
+/// The initialization of `Histogram`
+pub struct InitializedBoxPlot<Op> {
+    result_descriptor: PlotResultDescriptor,
+    column_names: Vec<String>,
+    interactive: bool,
+    source: Op,
+}
+
+impl<Op> InitializedBoxPlot<Op> {
+    pub fn new(result_descriptor: PlotResultDescriptor, params: BoxPlotParams, source: Op) -> Self {
+        Self {
+            result_descriptor,
+            column_names: params.column_names,
+            interactive: params.interactive,
+            source,
+        }
+    }
+}
+impl InitializedPlotOperator for InitializedBoxPlot<Box<dyn InitializedVectorOperator>> {
+    fn result_descriptor(&self) -> &PlotResultDescriptor {
+        &self.result_descriptor
+    }
+
+    fn query_processor(&self) -> Result<TypedPlotQueryProcessor> {
+        let processor = BoxPlotQueryProcessor {
+            input: self.source.query_processor()?,
+            column_names: self.column_names.clone(),
+            interactive: self.interactive,
+        };
+
+        Ok(TypedPlotQueryProcessor::JsonVega(processor.boxed()))
+    }
+}
+
+/// A query processor that calculates the boxplots about its vector inputs.
+pub struct BoxPlotQueryProcessor {
+    input: TypedVectorQueryProcessor,
+    column_names: Vec<String>,
+    interactive: bool,
+}
+
+#[async_trait]
+impl PlotQueryProcessor for BoxPlotQueryProcessor {
+    type OutputFormat = PlotData;
+
+    fn plot_type(&self) -> &'static str {
+        BOXPLOT_OPERATOR_NAME
+    }
+
+    async fn plot_query<'p>(
+        &'p self,
+        query: VectorQueryRectangle,
+        ctx: &'p dyn QueryContext,
+    ) -> Result<Self::OutputFormat> {
+        let mut accums: Vec<BoxPlotAccum> = self
+            .column_names
+            .iter()
+            .map(|name| BoxPlotAccum::new(name.clone()))
+            .collect();
+
+        call_on_generic_vector_processor!(&self.input, processor => {
+            let mut query = processor.query(query, ctx).await?;
+            while let Some(collection) = query.next().await {
+                let collection = collection?;
+
+                for accum in &mut accums {
+                    let feature_data = collection.data(&accum.name).expect("checked in param");
+                    let iter = feature_data.float_options_iter().map(|o| match o {
+                        Some(v) => v,
+                        None => f64::NAN,
+                    });
+                    accum.update(iter)?;
+                }
+            }
+        });
+
+        let mut chart = geoengine_datatypes::plots::BoxPlot::new();
+        for accum in &mut accums {
+            if let Some(attrib) = accum.finish()? {
+                chart.add_attribute(attrib)
+            }
+        }
+        Ok(chart.to_vega_embeddable(self.interactive)?)
+    }
+}
+
+struct BoxPlotAccum {
+    name: String,
+    values: Vec<f64>,
+    estimator: Option<PSquareQuantileEstimator<f64>>,
+}
+
+impl BoxPlotAccum {
+    fn new(name: String) -> BoxPlotAccum {
+        BoxPlotAccum {
+            name,
+            values: Vec::new(),
+            estimator: None,
+        }
+    }
+
+    fn update(&mut self, mut values: impl Iterator<Item = f64>) -> crate::util::Result<()> {
+        match self.estimator.as_mut() {
+            None => {
+                for v in &mut values {
+                    if !v.is_nan() {
+                        self.values.push(v);
+                    }
+                }
+            }
+            Some(est) => {
+                for v in &mut values {
+                    est.update(v);
+                }
+            }
+        }
+
+        // Turn into estimator
+        if self.estimator.is_none() && self.values.len() >= EXACT_CALC_BOUND {
+            let values = self.values.as_slice();
+            self.estimator
+                .replace(PSquareQuantileEstimator::new(0.5, values)?);
+        }
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<Option<geoengine_datatypes::plots::BoxPlotAttribute>> {
+        match self.estimator.as_ref() {
+            Some(est) => Ok(Some(BoxPlotAttribute::new(
+                self.name.clone(),
+                est.min(),
+                est.max(),
+                est.quantile_estimate(),
+                est.marker2(),
+                est.marker4(),
+                false,
+            )?)),
+            None if self.values.is_empty() => Ok(None),
+            None => {
+                self.values
+                    .sort_unstable_by(|a, b| a.partial_cmp(b).expect("Impossible"));
+                let min = self.values[0];
+                let max = self.values[self.values.len() - 1];
+                let median = self.values[self.values.len() / 2];
+                let q1 = self.values[(self.values.len() as f64 * 0.25) as usize];
+                let q3 = self.values[(self.values.len() as f64 * 0.75) as usize];
+
+                Ok(Some(BoxPlotAttribute::new(
+                    self.name.clone(),
+                    min,
+                    max,
+                    median,
+                    q1,
+                    q3,
+                    true,
+                )?))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use geoengine_datatypes::primitives::{
+        BoundingBox2D, FeatureData, NoGeometry, SpatialResolution, TimeInterval,
+    };
+    use geoengine_datatypes::{collections::DataCollection, primitives::MultiPoint};
+
+    use crate::engine::{MockExecutionContext, MockQueryContext, VectorOperator};
+    use crate::mock::MockFeatureCollectionSource;
+
+    use super::*;
+
+    #[test]
+    fn serialization() {
+        let histogram = BoxPlot {
+            params: BoxPlotParams {
+                column_names: vec!["foobar".to_string()],
+                interactive: false,
+            },
+            sources: MockFeatureCollectionSource::<MultiPoint>::multiple(vec![])
+                .boxed()
+                .into(),
+        };
+
+        let serialized = json!({
+            "type": "BoxPlot",
+            "params": {
+                "columnNames": ["foobar"],
+                "interactive": false,
+            },
+            "sources": {
+                "vector": {
+                    "type": "MockFeatureCollectionSourceMultiPoint",
+                    "params": {
+                        "collections": []
+                    }
+                }
+            }
+        })
+        .to_string();
+
+        let deserialized: BoxPlot = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized.params, histogram.params);
+    }
+
+    #[test]
+    fn serialization_alt() {
+        let histogram = BoxPlot {
+            params: BoxPlotParams {
+                column_names: vec![],
+                interactive: false,
+            },
+            sources: MockFeatureCollectionSource::<MultiPoint>::multiple(vec![])
+                .boxed()
+                .into(),
+        };
+
+        let serialized = json!({
+            "type": "BoxPlot",
+            "params": {
+            },
+            "sources": {
+                "vector": {
+                    "type": "MockFeatureCollectionSourceMultiPoint",
+                    "params": {
+                        "collections": []
+                    }
+                }
+            }
+        })
+        .to_string();
+
+        let deserialized: BoxPlot = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(deserialized.params, histogram.params);
+    }
+
+    #[tokio::test]
+    async fn vector_data() {
+        let vector_source = MockFeatureCollectionSource::multiple(vec![
+            DataCollection::from_slices(
+                &[] as &[NoGeometry],
+                &[TimeInterval::default(); 8],
+                &[
+                    ("foo", FeatureData::Int(vec![1, 1, 2, 2, 3, 3, 4, 4])),
+                    ("bar", FeatureData::Int(vec![1, 1, 2, 2, 3, 3, 4, 4])),
+                ],
+            )
+            .unwrap(),
+            DataCollection::from_slices(
+                &[] as &[NoGeometry],
+                &[TimeInterval::default(); 4],
+                &[
+                    ("foo", FeatureData::Int(vec![5, 6, 7, 8])),
+                    ("bar", FeatureData::Int(vec![5, 6, 7, 8])),
+                ],
+            )
+            .unwrap(),
+        ])
+        .boxed();
+
+        let box_plot = BoxPlot {
+            params: BoxPlotParams {
+                column_names: vec!["foo".to_string(), "bar".to_string()],
+                interactive: true,
+            },
+            sources: vector_source.into(),
+        };
+
+        let execution_context = MockExecutionContext::default();
+
+        let query_processor = box_plot
+            .boxed()
+            .initialize(&execution_context)
+            .await
+            .unwrap()
+            .query_processor()
+            .unwrap()
+            .json_vega()
+            .unwrap();
+
+        let result = query_processor
+            .plot_query(
+                VectorQueryRectangle {
+                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
+                        .unwrap(),
+                    time_interval: TimeInterval::default(),
+                    spatial_resolution: SpatialResolution::one(),
+                },
+                &MockQueryContext::new(0),
+            )
+            .await
+            .unwrap();
+
+        let mut expected = geoengine_datatypes::plots::BoxPlot::new();
+        expected.add_attribute(
+            BoxPlotAttribute::new("foo".to_string(), 1.0, 8.0, 4.0, 2.0, 6.0, true).unwrap(),
+        );
+        expected.add_attribute(
+            BoxPlotAttribute::new("bar".to_string(), 1.0, 8.0, 4.0, 2.0, 6.0, true).unwrap(),
+        );
+
+        assert_eq!(expected.to_vega_embeddable(false).unwrap(), result);
+    }
+
+    #[tokio::test]
+    async fn vector_data_with_nulls() {
+        let vector_source = MockFeatureCollectionSource::single(
+            DataCollection::from_slices(
+                &[] as &[NoGeometry],
+                &[TimeInterval::default(); 7],
+                &[(
+                    "foo",
+                    FeatureData::NullableFloat(vec![
+                        Some(1.),
+                        Some(2.),
+                        None,
+                        Some(4.),
+                        None,
+                        Some(6.),
+                        Some(7.),
+                    ]),
+                )],
+            )
+            .unwrap(),
+        )
+        .boxed();
+
+        let box_plot = BoxPlot {
+            params: BoxPlotParams {
+                column_names: vec!["foo".to_string()],
+                interactive: false,
+            },
+            sources: vector_source.into(),
+        };
+
+        let execution_context = MockExecutionContext::default();
+
+        let query_processor = box_plot
+            .boxed()
+            .initialize(&execution_context)
+            .await
+            .unwrap()
+            .query_processor()
+            .unwrap()
+            .json_vega()
+            .unwrap();
+
+        let result = query_processor
+            .plot_query(
+                VectorQueryRectangle {
+                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
+                        .unwrap(),
+                    time_interval: TimeInterval::default(),
+                    spatial_resolution: SpatialResolution::one(),
+                },
+                &MockQueryContext::new(0),
+            )
+            .await
+            .unwrap();
+
+        let mut expected = geoengine_datatypes::plots::BoxPlot::new();
+        expected.add_attribute(
+            BoxPlotAttribute::new("foo".to_string(), 1.0, 7.0, 4.0, 2.0, 6.0, true).unwrap(),
+        );
+
+        assert_eq!(expected.to_vega_embeddable(false).unwrap(), result);
+    }
+
+    #[tokio::test]
+    async fn vector_data_text_column() {
+        let vector_source = MockFeatureCollectionSource::single(
+            DataCollection::from_slices(
+                &[] as &[NoGeometry],
+                &[TimeInterval::default(); 1],
+                &[("foo", FeatureData::Text(vec!["test".to_string()]))],
+            )
+            .unwrap(),
+        )
+        .boxed();
+
+        let box_plot = BoxPlot {
+            params: BoxPlotParams {
+                column_names: vec!["foo".to_string()],
+                interactive: false,
+            },
+            sources: vector_source.into(),
+        };
+
+        let execution_context = MockExecutionContext::default();
+
+        let init = box_plot.boxed().initialize(&execution_context).await;
+
+        assert!(init.is_err());
+    }
+
+    #[tokio::test]
+    async fn vector_data_missing_column() {
+        let vector_source = MockFeatureCollectionSource::single(
+            DataCollection::from_slices(
+                &[] as &[NoGeometry],
+                &[TimeInterval::default(); 1],
+                &[("foo", FeatureData::Text(vec!["test".to_string()]))],
+            )
+            .unwrap(),
+        )
+        .boxed();
+
+        let box_plot = BoxPlot {
+            params: BoxPlotParams {
+                column_names: vec![],
+                interactive: false,
+            },
+            sources: vector_source.into(),
+        };
+
+        let execution_context = MockExecutionContext::default();
+
+        let init = box_plot.boxed().initialize(&execution_context).await;
+
+        assert!(init.is_err());
+    }
+
+    #[tokio::test]
+    async fn vector_data_single_feature() {
+        let vector_source =
+            MockFeatureCollectionSource::multiple(vec![DataCollection::from_slices(
+                &[] as &[NoGeometry],
+                &[TimeInterval::default(); 1],
+                &[("foo", FeatureData::Int(vec![1]))],
+            )
+            .unwrap()])
+            .boxed();
+
+        let box_plot = BoxPlot {
+            params: BoxPlotParams {
+                column_names: vec!["foo".to_string()],
+                interactive: true,
+            },
+            sources: vector_source.into(),
+        };
+
+        let execution_context = MockExecutionContext::default();
+
+        let query_processor = box_plot
+            .boxed()
+            .initialize(&execution_context)
+            .await
+            .unwrap()
+            .query_processor()
+            .unwrap()
+            .json_vega()
+            .unwrap();
+
+        let result = query_processor
+            .plot_query(
+                VectorQueryRectangle {
+                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
+                        .unwrap(),
+                    time_interval: TimeInterval::default(),
+                    spatial_resolution: SpatialResolution::one(),
+                },
+                &MockQueryContext::new(0),
+            )
+            .await
+            .unwrap();
+
+        let mut expected = geoengine_datatypes::plots::BoxPlot::new();
+        expected.add_attribute(
+            BoxPlotAttribute::new("foo".to_string(), 1.0, 1.0, 1.0, 1.0, 1.0, true).unwrap(),
+        );
+
+        assert_eq!(expected.to_vega_embeddable(false).unwrap(), result);
+    }
+
+    #[tokio::test]
+    async fn vector_data_empty() {
+        let vector_source =
+            MockFeatureCollectionSource::multiple(vec![DataCollection::from_slices(
+                &[] as &[NoGeometry],
+                &[] as &[TimeInterval],
+                &[("foo", FeatureData::Int(vec![]))],
+            )
+            .unwrap()])
+            .boxed();
+
+        let box_plot = BoxPlot {
+            params: BoxPlotParams {
+                column_names: vec!["foo".to_string()],
+                interactive: true,
+            },
+            sources: vector_source.into(),
+        };
+
+        let execution_context = MockExecutionContext::default();
+
+        let query_processor = box_plot
+            .boxed()
+            .initialize(&execution_context)
+            .await
+            .unwrap()
+            .query_processor()
+            .unwrap()
+            .json_vega()
+            .unwrap();
+
+        let result = query_processor
+            .plot_query(
+                VectorQueryRectangle {
+                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
+                        .unwrap(),
+                    time_interval: TimeInterval::default(),
+                    spatial_resolution: SpatialResolution::one(),
+                },
+                &MockQueryContext::new(0),
+            )
+            .await
+            .unwrap();
+
+        let expected = geoengine_datatypes::plots::BoxPlot::new();
+        assert_eq!(expected.to_vega_embeddable(false).unwrap(), result);
+    }
+
+    #[tokio::test]
+    async fn vector_data_estimator_switch() {
+        let mut data = Vec::<i64>::with_capacity(2 * super::EXACT_CALC_BOUND);
+
+        for i in 1..=data.capacity() as i64 {
+            data.push(i)
+        }
+
+        let vector_source =
+            MockFeatureCollectionSource::multiple(vec![DataCollection::from_slices(
+                &[] as &[NoGeometry],
+                &[TimeInterval::default(); 2 * super::EXACT_CALC_BOUND],
+                &[("foo", FeatureData::Int(data))],
+            )
+            .unwrap()])
+            .boxed();
+
+        let box_plot = BoxPlot {
+            params: BoxPlotParams {
+                column_names: vec!["foo".to_string()],
+                interactive: true,
+            },
+            sources: vector_source.into(),
+        };
+
+        let execution_context = MockExecutionContext::default();
+
+        let query_processor = box_plot
+            .boxed()
+            .initialize(&execution_context)
+            .await
+            .unwrap()
+            .query_processor()
+            .unwrap()
+            .json_vega()
+            .unwrap();
+
+        let result = query_processor
+            .plot_query(
+                VectorQueryRectangle {
+                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
+                        .unwrap(),
+                    time_interval: TimeInterval::default(),
+                    spatial_resolution: SpatialResolution::one(),
+                },
+                &MockQueryContext::new(0),
+            )
+            .await
+            .unwrap();
+
+        let mut expected = geoengine_datatypes::plots::BoxPlot::new();
+        expected.add_attribute(
+            BoxPlotAttribute::new(
+                "foo".to_string(),
+                1.0,
+                2.0 * super::EXACT_CALC_BOUND as f64,
+                super::EXACT_CALC_BOUND as f64,
+                0.5 * super::EXACT_CALC_BOUND as f64,
+                1.5 * super::EXACT_CALC_BOUND as f64,
+                false,
+            )
+            .unwrap(),
+        );
+
+        assert_eq!(expected.to_vega_embeddable(false).unwrap(), result);
+    }
+
+    // #[tokio::test]
+    // async fn no_data_raster() {
+    //     let no_data_value = Some(0);
+    //     let histogram = Histogram {
+    //         params: HistogramParams {
+    //             column_name: None,
+    //             bounds: HistogramBounds::Data(Data::default()),
+    //             buckets: None,
+    //             interactive: false,
+    //         },
+    //         sources: MockRasterSource {
+    //             params: MockRasterSourceParams {
+    //                 data: vec![RasterTile2D::new_with_tile_info(
+    //                     TimeInterval::default(),
+    //                     TileInformation {
+    //                         global_geo_transform: TestDefault::test_default(),
+    //                         global_tile_position: [0, 0].into(),
+    //                         tile_size_in_pixels: [3, 2].into(),
+    //                     },
+    //                     Grid2D::new([3, 2].into(), vec![0, 0, 0, 0, 0, 0], no_data_value)
+    //                         .unwrap()
+    //                         .into(),
+    //                 )],
+    //                 result_descriptor: RasterResultDescriptor {
+    //                     data_type: RasterDataType::U8,
+    //                     spatial_reference: SpatialReference::epsg_4326().into(),
+    //                     measurement: Measurement::Unitless,
+    //                     no_data_value: no_data_value.map(AsPrimitive::as_),
+    //                 },
+    //             },
+    //         }
+    //         .boxed()
+    //         .into(),
+    //     };
+    //
+    //     let execution_context = MockExecutionContext::default();
+    //
+    //     let query_processor = histogram
+    //         .boxed()
+    //         .initialize(&execution_context)
+    //         .await
+    //         .unwrap()
+    //         .query_processor()
+    //         .unwrap()
+    //         .json_vega()
+    //         .unwrap();
+    //
+    //     let result = query_processor
+    //         .plot_query(
+    //             VectorQueryRectangle {
+    //                 spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
+    //                     .unwrap(),
+    //                 time_interval: TimeInterval::default(),
+    //                 spatial_resolution: SpatialResolution::one(),
+    //             },
+    //             &MockQueryContext::new(0),
+    //         )
+    //         .await
+    //         .unwrap();
+    //
+    //     assert_eq!(
+    //         result,
+    //         geoengine_datatypes::plots::Histogram::builder(1, 0., 0., Measurement::Unitless)
+    //             .build()
+    //             .unwrap()
+    //             .to_vega_embeddable(false)
+    //             .unwrap()
+    //     );
+    // }
+    //
+    // #[tokio::test]
+    // async fn single_value_raster_stream() {
+    //     let execution_context = MockExecutionContext::default();
+    //
+    //     let no_data_value = None;
+    //     let histogram = Histogram {
+    //         params: HistogramParams {
+    //             column_name: None,
+    //             bounds: HistogramBounds::Data(Data::default()),
+    //             buckets: None,
+    //             interactive: false,
+    //         },
+    //         sources: MockRasterSource {
+    //             params: MockRasterSourceParams {
+    //                 data: vec![RasterTile2D::new_with_tile_info(
+    //                     TimeInterval::default(),
+    //                     TileInformation {
+    //                         global_geo_transform: TestDefault::test_default(),
+    //                         global_tile_position: [0, 0].into(),
+    //                         tile_size_in_pixels: [3, 2].into(),
+    //                     },
+    //                     Grid2D::new([3, 2].into(), vec![4; 6], no_data_value)
+    //                         .unwrap()
+    //                         .into(),
+    //                 )],
+    //                 result_descriptor: RasterResultDescriptor {
+    //                     data_type: RasterDataType::U8,
+    //                     spatial_reference: SpatialReference::epsg_4326().into(),
+    //                     measurement: Measurement::Unitless,
+    //                     no_data_value: no_data_value.map(AsPrimitive::as_),
+    //                 },
+    //             },
+    //         }
+    //         .boxed()
+    //         .into(),
+    //     };
+    //
+    //     let query_processor = histogram
+    //         .boxed()
+    //         .initialize(&execution_context)
+    //         .await
+    //         .unwrap()
+    //         .query_processor()
+    //         .unwrap()
+    //         .json_vega()
+    //         .unwrap();
+    //
+    //     let result = query_processor
+    //         .plot_query(
+    //             VectorQueryRectangle {
+    //                 spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
+    //                     .unwrap(),
+    //                 time_interval: TimeInterval::new_instant(
+    //                     NaiveDate::from_ymd(2013, 12, 1).and_hms(12, 0, 0),
+    //                 )
+    //                 .unwrap(),
+    //                 spatial_resolution: SpatialResolution::one(),
+    //             },
+    //             &MockQueryContext::default(),
+    //         )
+    //         .await
+    //         .unwrap();
+    //
+    //     assert_eq!(
+    //         result,
+    //         geoengine_datatypes::plots::Histogram::builder(1, 4., 4., Measurement::Unitless)
+    //             .counts(vec![6])
+    //             .build()
+    //             .unwrap()
+    //             .to_vega_embeddable(false)
+    //             .unwrap()
+    //     );
+    // }
+}

--- a/operators/src/plot/mod.rs
+++ b/operators/src/plot/mod.rs
@@ -1,3 +1,4 @@
+mod box_plot;
 mod histogram;
 mod statistics;
 mod temporal_raster_mean_plot;

--- a/operators/src/util/mod.rs
+++ b/operators/src/util/mod.rs
@@ -4,6 +4,7 @@ pub mod math;
 pub mod number_statistics;
 pub mod raster_stream_to_geotiff;
 pub mod raster_stream_to_png;
+pub mod statistics;
 pub mod string_token;
 pub mod sunpos;
 

--- a/operators/src/util/statistics.rs
+++ b/operators/src/util/statistics.rs
@@ -1,0 +1,444 @@
+use num_traits::AsPrimitive;
+use snafu::Snafu;
+use std::marker::PhantomData;
+
+/// Enum for any errors encountered while creating statistics.
+#[derive(Debug, Snafu)]
+pub enum StatisticsError {
+    #[snafu(display("Error initializing statistics. Reason: {}", reason))]
+    Initialization { reason: String },
+    #[snafu(display("Cannot compute statistics on empty sample."))]
+    Empty,
+}
+
+/// Single quantile estimation with the P^2 algorithm
+///
+/// The P^2 algorithm estimates a quantile dynamically without storing samples. Instead of
+/// storing the whole sample cumulative distribution, only five points (markers) are stored. The heights
+/// of these markers are the minimum and the maximum of the samples and the current estimates of the
+/// (p/2)-, p- and (1+p)/2-quantiles. Their positions are equal to the number
+/// of samples that are smaller or equal to the markers. Each time a new samples is recorded, the
+/// positions of the markers are updated and if necessary their heights are adjusted using a piecewise-
+/// parabolic formula.
+///
+/// For further details, see
+///
+/// R. Jain and I. Chlamtac, The P^2 algorithm for dynamic calculation of quantiles and
+/// histograms without storing observations, Communications of the ACM,
+/// Volume 28 (October), Number 10, 1985, p. 1076-1085.
+/// <https://www.cse.wustl.edu/~jain/papers/ftp/psqr.pdf>
+///
+#[derive(Debug)]
+pub struct PSquareQuantileEstimator<T>
+where
+    T: AsPrimitive<f64>,
+{
+    quantile: f64,
+    positions: [i64; 5],
+    markers: [f64; 5],
+    desired: [f64; 5],
+    increment: [f64; 5],
+    sample_count: u64,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> PSquareQuantileEstimator<T>
+where
+    T: AsPrimitive<f64>,
+{
+    /// Creates a new estimator for the given quantile. The estimator is
+    /// update with all valid values from the given `initial_samples`.
+    /// The initial samples must at least contain 5 valid elements
+    /// (i.e., 5 elements that do not translate to `f64::NAN`).
+    ///
+    /// # Panics
+    /// If the given quantile is not within the interval (0,1).
+    ///
+    /// # Errors
+    /// If the `initial_samples` contain less than 5 valid elements.
+    pub fn new(
+        quantile: f64,
+        initial_samples: &[T],
+    ) -> Result<PSquareQuantileEstimator<T>, StatisticsError> {
+        assert!(
+            quantile > 0.0 && quantile < 1.0,
+            "The desired quantile must be in the interval (0,1)"
+        );
+
+        // Initialize marker positions
+        let positions = [1, 2, 3, 4, 5];
+
+        // Initialize desired marker positions
+        let desired = [
+            1.0,
+            1.0 + 2.0 * quantile,
+            1.0 + 4.0 * quantile,
+            3.0 + 2.0 * quantile,
+            5.0,
+        ];
+        // Initialize marker increment
+        let increment = [0.0, quantile / 2.0, quantile, (1.0 + quantile) / 2.0, 1.0];
+
+        // Initialize marker values
+        let mut markers = [0.0; 5];
+        let mut iter = initial_samples.iter();
+        let mut sample_count = 0;
+
+        for v in &mut iter {
+            let v: f64 = v.as_();
+            if !v.is_nan() {
+                markers[sample_count] = v;
+                sample_count += 1;
+                if sample_count > 4 {
+                    break;
+                }
+            }
+        }
+
+        // We require at least 5 valid initial samples
+        if sample_count < 5 {
+            return Err(StatisticsError::Initialization {
+                reason: "Insufficient valid samples.".to_owned(),
+            });
+        }
+
+        markers.sort_unstable_by(|a, b| a.partial_cmp(b).expect("impossible"));
+
+        let mut result = PSquareQuantileEstimator {
+            quantile,
+            positions,
+            markers,
+            desired,
+            increment,
+            sample_count: sample_count as u64,
+            _phantom: PhantomData {},
+        };
+
+        // Add remaining values
+
+        for v in &mut iter {
+            result.update(*v)
+        }
+        Ok(result)
+    }
+
+    fn marker_value(&self, idx: usize) -> f64 {
+        self.markers[idx]
+    }
+
+    /// Returns the quantile to estimate
+    pub fn quantile(&self) -> f64 {
+        self.quantile
+    }
+
+    /// Returns the number of samples seen so far
+    pub fn sample_count(&self) -> u64 {
+        self.sample_count
+    }
+
+    /// Returns the minimum of the samples seen so far
+    pub fn min(&self) -> f64 {
+        self.marker_value(0)
+    }
+
+    /// Returns the minimum of the samples seen so far
+    pub fn max(&self) -> f64 {
+        self.marker_value(4)
+    }
+
+    /// Returns the quantile estimate based on the samples seen so far
+    pub fn quantile_estimate(&self) -> f64 {
+        self.marker_value(2)
+    }
+
+    /// Returns the value of the second marker (i.e., an estimate of the p/2 quantile).
+    pub fn marker2(&self) -> f64 {
+        self.marker_value(1)
+    }
+
+    /// Returns the value of the fourth marker (i.e., an estimate of the (1+p)/2 quantile).
+    pub fn marker4(&self) -> f64 {
+        self.marker_value(3)
+    }
+
+    /// Updates the estimator with the given sample.
+    pub fn update(&mut self, sample: T) {
+        let val: f64 = sample.as_();
+
+        // Ignore NANs
+        if val.is_nan() {
+            return;
+        }
+
+        self.sample_count += 1;
+
+        // Find bucket
+        let idx = if val < self.markers[0] {
+            self.markers[0] = val;
+            0
+        } else if val < self.markers[1] {
+            0
+        } else if val < self.markers[2] {
+            1
+        } else if val < self.markers[3] {
+            2
+        } else if val < self.markers[4] {
+            3
+        } else {
+            self.markers[4] = val;
+            3
+        };
+
+        // Shift marker positions
+        for i in (idx + 1)..5 {
+            self.positions[i] += 1;
+        }
+
+        // Update desired positions
+        for i in 0..5 {
+            self.desired[i] += self.increment[i];
+        }
+
+        // Adjust marker height
+        for i in 1..4 {
+            let delta = self.desired[i] - self.positions[i] as f64;
+
+            // Check if an adjustment is required
+            if delta >= 1.0 && self.positions[i + 1] - self.positions[i] > 1
+                || delta <= -1.0 && self.positions[i - 1] - self.positions[i] < -1
+            {
+                let delta = delta.signum();
+
+                // Apply p^2 formula
+                let mut val = self.estimate_marker_psquare(i, delta);
+
+                // Apply linear estimation if value is invalid
+                if self.markers[i - 1] >= val || val >= self.markers[i + 1] {
+                    val = self.estimate_marker_linear(i, delta);
+                }
+                self.markers[i] = val;
+                self.positions[i] += delta as i64;
+            }
+        }
+    }
+
+    /// Estimates the new value of the `i-th` marker linearly
+    fn estimate_marker_linear(&self, i: usize, delta: f64) -> f64 {
+        let neighbor_idx = if delta < 0.0 { i - 1 } else { i + 1 };
+        self.markers[i]
+            + delta
+                * ((self.markers[neighbor_idx] - self.markers[i])
+                    / (self.positions[neighbor_idx] - self.positions[i]) as f64)
+    }
+
+    /// Estimates the new value of the `i-th` marker using the p^2 method
+    fn estimate_marker_psquare(&self, i: usize, delta: f64) -> f64 {
+        let pos = self.positions[i] as f64;
+        let pos_prev = self.positions[i - 1] as f64;
+        let pos_next = self.positions[i + 1] as f64;
+
+        let base = delta / (pos_next - pos_prev);
+        let left =
+            (pos - pos_prev + delta) * ((self.markers[i + 1] - self.markers[i]) / (pos_next - pos));
+        let right =
+            (pos_next - pos - delta) * ((self.markers[i] - self.markers[i - 1]) / (pos - pos_prev));
+        self.markers[i] + base * (left + right) //* pos
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::util::statistics::PSquareQuantileEstimator;
+    use rand::seq::SliceRandom;
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn test_paper_example() {
+        let data = vec![
+            0.02, 0.15, 0.74, 3.39, 0.83, 22.37, 10.15, 15.43, 38.62, 15.92, 34.60, 10.28, 1.47,
+            0.40, 0.05, 11.39, 0.27, 0.42, 0.09, 11.37,
+        ];
+
+        let expected_markers = [
+            [0.02, 0.15, 0.74, 0.83, 22.37],
+            [0.02, 0.15, 0.74, 4.465, 22.37],
+            [
+                0.02,
+                0.15,
+                2.178_333_333_333_333,
+                8.592_500_000_000_001,
+                22.37,
+            ],
+            [
+                0.02,
+                0.869_444_444_444_444_2,
+                4.752_685_185_185_185,
+                15.516_990_740_740_741,
+                38.62,
+            ],
+            [
+                0.02,
+                0.869_444_444_444_444_2,
+                4.752_685_185_185_185,
+                15.516_990_740_740_741,
+                38.62,
+            ],
+            [
+                0.02,
+                0.869_444_444_444_444_2,
+                9.274_704_861_111_111,
+                21.572_663_194_444_445,
+                38.62,
+            ],
+            [
+                0.02,
+                0.869_444_444_444_444_2,
+                9.274_704_861_111_111,
+                21.572_663_194_444_445,
+                38.62,
+            ],
+            [
+                0.02,
+                2.132_463_107_638_888_5,
+                9.274_704_861_111_111,
+                21.572_663_194_444_445,
+                38.62,
+            ],
+            [
+                0.02,
+                2.132_463_107_638_888_5,
+                9.274_704_861_111_111,
+                21.572_663_194_444_445,
+                38.62,
+            ],
+            [
+                0.02,
+                0.730_843_171_296_295_7,
+                6.297_302_000_661_376,
+                21.572_663_194_444_445,
+                38.62,
+            ],
+            [
+                0.02,
+                0.730_843_171_296_295_7,
+                6.297_302_000_661_376,
+                21.572_663_194_444_445,
+                38.62,
+            ],
+            [
+                0.02,
+                0.588_674_537_037_036_5,
+                6.297_302_000_661_376,
+                17.203_904_274_140_214,
+                38.62,
+            ],
+            [
+                0.02,
+                0.588_674_537_037_036_5,
+                6.297_302_000_661_376,
+                17.203_904_274_140_214,
+                38.62,
+            ],
+            [
+                0.02,
+                0.493_895_447_530_863_8,
+                4.440_634_353_260_337,
+                17.203_904_274_140_214,
+                38.62,
+            ],
+            [
+                0.02,
+                0.493_895_447_530_863_8,
+                4.440_634_353_260_337,
+                17.203_904_274_140_214,
+                38.62,
+            ],
+        ];
+
+        let expected_positions: [[i64; 5]; 15] = [
+            [1, 2, 3, 4, 6],
+            [1, 2, 3, 5, 7],
+            [1, 2, 4, 6, 8],
+            [1, 3, 5, 7, 9],
+            [1, 3, 5, 7, 10],
+            [1, 3, 6, 8, 11],
+            [1, 3, 6, 9, 12],
+            [1, 4, 7, 10, 13],
+            [1, 5, 8, 11, 14],
+            [1, 5, 8, 12, 15],
+            [1, 5, 8, 13, 16],
+            [1, 5, 9, 13, 17],
+            [1, 6, 10, 14, 18],
+            [1, 6, 10, 15, 19],
+            [1, 6, 10, 16, 20],
+        ];
+
+        let mut estimator = PSquareQuantileEstimator::new(0.5, &data.as_slice()[0..5]).unwrap();
+
+        for (idx, &v) in data.as_slice()[5..].iter().enumerate() {
+            estimator.update(v);
+            assert_eq!(expected_positions[idx], estimator.positions);
+            for i in 0..5 {
+                float_cmp::assert_approx_eq!(f64, expected_markers[idx][i], estimator.markers[i]);
+            }
+        }
+    }
+
+    #[test]
+    fn test_all_markers() {
+        let mut data = Vec::<i32>::with_capacity(100_000);
+
+        for v in 1..=100_000 {
+            data.push(v);
+        }
+
+        let mut rng = rand::thread_rng();
+        data.shuffle(&mut rng);
+
+        let estimator = PSquareQuantileEstimator::new(0.5, data.as_slice()).unwrap();
+
+        float_cmp::assert_approx_eq!(f64, 1.0, estimator.min());
+        float_cmp::assert_approx_eq!(f64, 100_000.0, estimator.max());
+        assert!((50000.0 - estimator.quantile_estimate()).abs() < 50.0);
+        assert!((25000.0 - estimator.marker2()).abs() < 50.0);
+        assert!((75000.0 - estimator.marker4()).abs() < 50.0);
+    }
+
+    #[test]
+    fn test_bad_initial_value() {
+        let initial = vec![0.02, 0.15, f64::NAN, 3.39, 0.83];
+        let estimator = PSquareQuantileEstimator::new(0.5, initial.as_slice());
+        assert!(estimator.is_err());
+    }
+
+    #[test]
+    fn test_bad_value() {
+        let initial = vec![0.02, 0.15, 0.74, 3.39, 0.83];
+
+        let mut estimator = PSquareQuantileEstimator::new(0.5, initial.as_slice()).unwrap();
+
+        let samples = estimator.sample_count();
+
+        estimator.update(f64::NAN);
+
+        assert_eq!(samples, estimator.sample_count());
+
+        estimator.update(42.0);
+
+        assert_eq!(samples + 1, estimator.sample_count());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bad_quantile() {
+        let initial = vec![0.02, 0.15, 0.74, 3.39, 0.83];
+        PSquareQuantileEstimator::new(1.2, initial.as_slice()).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bad_quantile2() {
+        let initial = vec![0.02, 0.15, 0.74, 3.39, 0.83];
+        PSquareQuantileEstimator::new(-1.0, initial.as_slice()).unwrap();
+    }
+}


### PR DESCRIPTION
Implemented box plots for vector and raster data. For many data points (currently > 10000) the operator uses the P^2 algorithm to estimate quantiles. For details see:
R. Jain and I. Chlamtac, The P^2 algorithm for dynamic calculation of quantiles and
histograms without storing observations, Communications of the ACM,
Volume 28 (October), Number 10, 1985, p. 1076-1085.
(https://www.cse.wustl.edu/~jain/papers/ftp/psqr.pdf)