### PR TITLE
Override config with environment variables

### DIFF
--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -19,12 +19,12 @@ gfbio = ["postgres", "geoengine-datatypes/postgres"]
 pro = ["postgres", "geoengine-operators/pro", "geoengine-datatypes/pro"]
 
 [dependencies]
-actix-files = "0.6.0-beta.8"
-actix-http = "=3.0.0-beta.12"
-actix-multipart = "0.4.0-beta.7"
-actix-rt = "2.2"
-actix-web = "=4.0.0-beta.11"
-actix-web-httpauth = "0.6.0-beta.3"
+actix-files = "=0.6.0-beta.9"
+actix-http = "=3.0.0-beta.13"
+actix-multipart = "=0.4.0-beta.8"
+actix-rt = "2.5"
+actix-web = "=4.0.0-beta.12"
+actix-web-httpauth = "=0.6.0-beta.4"
 async-trait = "0.1"
 base64 = "0.13"
 bb8-postgres = { version = "0.7", features = ["with-uuid-0_8", "with-chrono-0_4", "with-serde_json-1"], optional = true }

--- a/services/src/handlers/upload.rs
+++ b/services/src/handlers/upload.rs
@@ -56,7 +56,6 @@ async fn upload_handler<C: Context>(
         let mut field = item?;
         let file_name = field
             .content_disposition()
-            .ok_or(error::Error::UploadFieldMissingFileName)?
             .get_filename()
             .ok_or(error::Error::UploadFieldMissingFileName)?
             .to_owned();

--- a/services/src/server.rs
+++ b/services/src/server.rs
@@ -6,7 +6,7 @@ use crate::util::config;
 use crate::util::config::get_config_element;
 
 use actix_files::Files;
-use actix_web::dev::{Body, ServiceResponse};
+use actix_web::dev::{AnyBody, ServiceResponse};
 use actix_web::error::{InternalError, JsonPayloadError, QueryPayloadError};
 use actix_web::{http, middleware, web, App, HttpResponse, HttpServer};
 use log::{debug, info};
@@ -212,13 +212,13 @@ pub(crate) async fn show_version_handler() -> impl actix_web::Responder {
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn render_404(
     mut res: ServiceResponse,
-) -> actix_web::Result<middleware::ErrorHandlerResponse<Body>> {
+) -> actix_web::Result<middleware::ErrorHandlerResponse<AnyBody>> {
     res.headers_mut().insert(
         http::header::CONTENT_TYPE,
         http::HeaderValue::from_static("application/json"),
     );
     let res = res.map_body(|_, _| {
-        Body::from(
+        AnyBody::from(
             serde_json::to_string(&ErrorResponse {
                 error: "NotFound".to_string(),
                 message: "Not Found".to_string(),
@@ -232,13 +232,13 @@ pub(crate) fn render_404(
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn render_405(
     mut res: ServiceResponse,
-) -> actix_web::Result<middleware::ErrorHandlerResponse<Body>> {
+) -> actix_web::Result<middleware::ErrorHandlerResponse<AnyBody>> {
     res.headers_mut().insert(
         http::header::CONTENT_TYPE,
         http::HeaderValue::from_static("application/json"),
     );
     let res = res.map_body(|_, _| {
-        Body::from(
+        AnyBody::from(
             serde_json::to_string(&ErrorResponse {
                 error: "MethodNotAllowed".to_string(),
                 message: "HTTP method not allowed.".to_string(),

--- a/services/src/util/config.rs
+++ b/services/src/util/config.rs
@@ -6,7 +6,7 @@ use crate::error::{self, Result};
 use crate::util::parsing::{deserialize_base_url, deserialize_base_url_option};
 
 use chrono::{DateTime, FixedOffset};
-use config::{Config, File};
+use config::{Config, Environment, File};
 use geoengine_datatypes::primitives::{TimeInstance, TimeInterval};
 use geoengine_operators::util::raster_stream_to_geotiff::GdalCompressionNumThreads;
 use lazy_static::lazy_static;
@@ -34,6 +34,12 @@ lazy_static! {
             .collect();
 
         settings.merge(files).unwrap();
+
+        // Override config with environment variables that start with `GEOENGINE_`,
+        // e.g. `GEOENGINE_WEB__EXTERNAL_ADDRESS=https://path.to.geoengine.io`
+        // Note: Since variables contain underscores, we need to use something different
+        // for seperating groups, for instance double underscores `__`
+        settings.merge(Environment::with_prefix("geoengine").separator("__")).unwrap();
 
         settings
     });


### PR DESCRIPTION
You can now override the configuration with environment variables.

An example:

```bash
GEOENGINE_WEB__EXTERNAL_ADDRESS=https://path.to.geoengine.io cargo run
```

You see that it worked on startup:

> [2021-11-24 13:42:41.000167 +01:00] INFO [geoengine_services::server] Starting server… https://path.to.geoengine.io/