### PR TITLE
Build-rs

### DIFF
--- a/datatypes/src/operations/image/colorizer.rs
+++ b/datatypes/src/operations/image/colorizer.rs
@@ -529,6 +529,7 @@ impl RgbaColor {
     /// On debug, if factor is not in [0, 1]
     ///
     #[allow(unstable_name_collisions)]
+    #[must_use]
     pub fn factor_add(self, other: Self, factor: f64) -> Self {
         debug_assert!((0.0..=1.0).contains(&factor));
 

--- a/datatypes/src/plots/histogram.rs
+++ b/datatypes/src/plots/histogram.rs
@@ -325,12 +325,14 @@ impl HistogramBuilder {
     ///     .build()
     ///     .unwrap();
     /// ```
+    #[must_use]
     pub fn labels(mut self, labels: Vec<String>) -> Self {
         self.labels = Some(labels);
         self
     }
 
     /// Add counts to the histogram
+    #[must_use]
     pub fn counts(mut self, counts: Vec<u64>) -> Self {
         self.counts = Some(counts);
         self

--- a/datatypes/src/primitives/circle.rs
+++ b/datatypes/src/primitives/circle.rs
@@ -105,6 +105,7 @@ impl Circle {
     }
 
     /// Enlarges the circle by the given delta
+    #[must_use]
     pub fn buffer(&self, delta: f64) -> Self {
         Circle {
             center: self.center,

--- a/datatypes/src/primitives/coordinate.rs
+++ b/datatypes/src/primitives/coordinate.rs
@@ -42,6 +42,7 @@ impl Coordinate2D {
         Self { x, y }
     }
 
+    #[must_use]
     pub fn min_elements(&self, other: Self) -> Self {
         Coordinate2D {
             x: self.x.min(other.x),
@@ -49,6 +50,7 @@ impl Coordinate2D {
         }
     }
 
+    #[must_use]
     pub fn max_elements(&self, other: Self) -> Self {
         Coordinate2D {
             x: self.x.max(other.x),

--- a/datatypes/src/primitives/spatial_partition.rs
+++ b/datatypes/src/primitives/spatial_partition.rs
@@ -191,6 +191,7 @@ impl SpatialPartition2D {
     }
 
     /// Align this partition by snapping bounds to the pixel borders defined by `origin` and `resolution`
+    #[must_use]
     pub fn snap_to_grid(&self, origin: Coordinate2D, resolution: SpatialResolution) -> Self {
         Self {
             upper_left_coordinate: (

--- a/datatypes/src/primitives/time_interval.rs
+++ b/datatypes/src/primitives/time_interval.rs
@@ -304,6 +304,7 @@ impl TimeInterval {
 
     /// Extends a time interval with the bounds of another time interval.
     /// The result has the smaller `start` and the larger `end`.
+    #[must_use]
     pub fn extend(&self, other: &Self) -> TimeInterval {
         Self {
             start: self.start.min(other.start),

--- a/datatypes/tests/example-arrow.rs
+++ b/datatypes/tests/example-arrow.rs
@@ -676,7 +676,7 @@ fn multipoint_builder_bytes() {
 
     let floats: &[Coordinate2D] = unsafe {
         std::slice::from_raw_parts(
-            first_multi_point.value(0)[0] as *const u8 as *const _,
+            first_multi_point.value(0).as_ptr() as *const _,
             first_multi_point.len(),
         )
     };
@@ -688,7 +688,7 @@ fn multipoint_builder_bytes() {
 
     let floats: &[Coordinate2D] = unsafe {
         std::slice::from_raw_parts(
-            second_multi_point.value(0)[0] as *const u8 as *const _,
+            second_multi_point.value(0).as_ptr() as *const _,
             second_multi_point.len(),
         )
     };

--- a/operators/Cargo.toml
+++ b/operators/Cargo.toml
@@ -36,7 +36,7 @@ rustc-hash = { version = "1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu = "0.6"
-tokio = { version = "1.1", features = ["macros", "signal", "sync", "rt-multi-thread"] }
+tokio = { version = "1.15", features = ["macros", "signal", "sync", "rt-multi-thread"] }
 typetag = "0.1"
 uuid = { version = "0.8", features = ["serde", "v4", "v5"] }
 

--- a/operators/src/engine/result_descriptor.rs
+++ b/operators/src/engine/result_descriptor.rs
@@ -17,6 +17,7 @@ pub trait ResultDescriptor: Clone + Serialize {
     fn spatial_reference(&self) -> SpatialReferenceOption;
 
     /// Map one descriptor to another one
+    #[must_use]
     fn map<F>(&self, f: F) -> Self
     where
         F: Fn(&Self) -> Self,
@@ -25,11 +26,13 @@ pub trait ResultDescriptor: Clone + Serialize {
     }
 
     /// Map one descriptor to another one by modifying only the spatial reference
+    #[must_use]
     fn map_data_type<F>(&self, f: F) -> Self
     where
         F: Fn(&Self::DataType) -> Self::DataType;
 
     /// Map one descriptor to another one by modifying only the data type
+    #[must_use]
     fn map_spatial_reference<F>(&self, f: F) -> Self
     where
         F: Fn(&SpatialReferenceOption) -> SpatialReferenceOption;
@@ -90,6 +93,7 @@ pub struct VectorResultDescriptor {
 
 impl VectorResultDescriptor {
     /// Create a new `VectorResultDescriptor` by only modifying the columns
+    #[must_use]
     pub fn map_columns<F>(&self, f: F) -> Self
     where
         F: Fn(&HashMap<String, FeatureDataType>) -> HashMap<String, FeatureDataType>,

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-12-09"
+channel = "nightly-2021-12-20"
 components = ["cargo", "rustfmt", "rust-src", "clippy"]

--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -75,5 +75,4 @@ walkdir = "2.3"
 xml-rs = "0.8.3"
 
 [build-dependencies]
-anyhow = "1.0.40"
-vergen = "5"
+vergen = "6"

--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -19,12 +19,12 @@ gfbio = ["postgres", "geoengine-datatypes/postgres"]
 pro = ["postgres", "geoengine-operators/pro", "geoengine-datatypes/pro"]
 
 [dependencies]
-actix-files = "=0.6.0-beta.9"
-actix-http = "=3.0.0-beta.14"
+actix-files = "=0.6.0-beta.10"
+actix-http = "=3.0.0-beta.16"
 actix-multipart = "=0.4.0-beta.9"
 actix-rt = "2.5"
-actix-web = "=4.0.0-beta.13"
-actix-web-httpauth = "=0.6.0-beta.4"
+actix-web = "=4.0.0-beta.15"
+actix-web-httpauth = "=0.6.0-beta.6"
 async-trait = "0.1"
 base64 = "0.13"
 bb8-postgres = { version = "0.7", features = ["with-uuid-0_8", "with-chrono-0_4", "with-serde_json-1"], optional = true }

--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -60,7 +60,7 @@ serde_with = "1.9"
 snafu = "0.6"
 strum = { version = "0.23", features = ["derive"] }
 time = "0.3"
-tokio = { version = "1.1", features = ["macros", "fs", "signal", "sync", "rt-multi-thread"] }
+tokio = { version = "1.15", features = ["macros", "fs", "signal", "sync", "rt-multi-thread"] }
 tokio-util = "0.6"
 typetag = "0.1"
 url = { version = "2.2", features = ["serde"] }

--- a/services/build.rs
+++ b/services/build.rs
@@ -1,10 +1,9 @@
-use anyhow::Result;
 use vergen::{vergen, Config, TimestampKind};
 
-fn main() -> Result<()> {
+fn main() {
     let mut config = Config::default();
 
     *config.build_mut().kind_mut() = TimestampKind::DateOnly;
 
-    vergen(config)
+    vergen(config).expect("Unable to generate version info");
 }

--- a/services/src/handlers/projects.rs
+++ b/services/src/handlers/projects.rs
@@ -271,8 +271,6 @@ mod tests {
     }
 
     #[tokio::test]
-    // TODO: remove when https://github.com/tokio-rs/tokio/issues/4245 is fixed
-    #[allow(clippy::semicolon_if_nothing_returned)]
     async fn create() {
         let res = create_test_helper(Method::POST).await;
 
@@ -447,8 +445,6 @@ mod tests {
     }
 
     #[tokio::test]
-    // TODO: remove when https://github.com/tokio-rs/tokio/issues/4245 is fixed
-    #[allow(clippy::semicolon_if_nothing_returned)]
     async fn load() {
         let res = load_test_helper(Method::GET).await;
 

--- a/services/src/handlers/session.rs
+++ b/services/src/handlers/session.rs
@@ -205,8 +205,6 @@ mod tests {
     }
 
     #[tokio::test]
-    // TODO: remove when https://github.com/tokio-rs/tokio/issues/4245 is fixed
-    #[allow(clippy::semicolon_if_nothing_returned)]
     async fn anonymous() {
         let res = anonymous_test_helper(Method::POST).await;
 

--- a/services/src/handlers/workflows.rs
+++ b/services/src/handlers/workflows.rs
@@ -505,8 +505,6 @@ mod tests {
     }
 
     #[tokio::test]
-    // TODO: remove when https://github.com/tokio-rs/tokio/issues/4245 is fixed
-    #[allow(clippy::semicolon_if_nothing_returned)]
     async fn register() {
         let res = register_test_helper(Method::POST).await;
 

--- a/services/src/pro/handlers/projects.rs
+++ b/services/src/pro/handlers/projects.rs
@@ -676,8 +676,6 @@ mod tests {
     }
 
     #[tokio::test]
-    // TODO: remove when https://github.com/tokio-rs/tokio/issues/4245 is fixed
-    #[allow(clippy::semicolon_if_nothing_returned)]
     async fn versions() {
         let res = versions_test_helper(Method::GET).await;
 

--- a/services/src/pro/handlers/users.rs
+++ b/services/src/pro/handlers/users.rs
@@ -276,8 +276,6 @@ mod tests {
     }
 
     #[tokio::test]
-    // TODO: remove when https://github.com/tokio-rs/tokio/issues/4245 is fixed
-    #[allow(clippy::semicolon_if_nothing_returned)]
     async fn register() {
         let ctx = ProInMemoryContext::default();
 
@@ -424,8 +422,6 @@ mod tests {
     }
 
     #[tokio::test]
-    // TODO: remove when https://github.com/tokio-rs/tokio/issues/4245 is fixed
-    #[allow(clippy::semicolon_if_nothing_returned)]
     async fn login() {
         let res = login_test_helper(Method::POST, "secret123").await;
 

--- a/services/src/pro/util/tests.rs
+++ b/services/src/pro/util/tests.rs
@@ -127,5 +127,7 @@ where
         app = app.configure(pro::handlers::drone_mapping::init_drone_mapping_routes::<C>);
     }
     let app = test::init_service(app).await;
-    test::call_service(&app, req.to_request()).await
+    test::call_service(&app, req.to_request())
+        .await
+        .map_into_boxed_body()
 }

--- a/services/src/util/parsing.rs
+++ b/services/src/util/parsing.rs
@@ -135,7 +135,7 @@ mod tests {
         impl Display for Test {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 match &self.base_url {
-                    Some(base_url) => f.write_str(&base_url.to_string()),
+                    Some(base_url) => f.write_str(base_url.as_ref()),
                     None => f.write_str(""),
                 }
             }

--- a/services/src/util/tests.rs
+++ b/services/src/util/tests.rs
@@ -243,8 +243,10 @@ pub fn initialize_debugging_in_test() {
 }
 
 pub trait SetMultipartBody {
+    #[must_use]
     fn set_multipart<B: Into<Vec<u8>>>(self, parts: Vec<(&str, B)>) -> Self;
 
+    #[must_use]
     fn set_multipart_files(self, file_paths: &[PathBuf]) -> Self
     where
         Self: Sized,

--- a/services/src/util/tests.rs
+++ b/services/src/util/tests.rs
@@ -208,7 +208,9 @@ pub async fn send_test_request<C: SimpleContext>(
             .configure(handlers::workflows::init_workflow_routes::<C>),
     )
     .await;
-    test::call_service(&app, req.to_request()).await
+    test::call_service(&app, req.to_request())
+        .await
+        .map_into_boxed_body()
 }
 
 pub async fn read_body_string(res: ServiceResponse) -> String {


### PR DESCRIPTION
I did the following things:

1. Removed `anyhow` from our build-dependencies and just unwrapped the result in the `build.rs` file.
2. Clippy wanted to add #[must_use] labels to functions that take `&self` and return `Self`. This makes sense since not using would mean you did something wrong.
3. The arrow example was not working anymore :shrug:. I changed the pointer cast. Fortunately, it seems that our in-code conversions still work.
4. I updated `tokio` and could remove some Clippy lint exclusions (`// TODO: remove when https://github.com/tokio-rs/tokio/issues/4245 is fixed`).
5. I updated Actix-web and they removed `AnyBody`. This means I had to wrap our error handler differently. You now have to put it into an EitherBody-enum and this takes a BoxBody. So I had to call `boxed()` here as well. Please check that the HTTP responses still work, for me, it looks fine.