### PR TITLE
cleanup(remove docker references)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,0 @@
-# Don't provide build directory to Docker context
-target
-
-# Ignore dockerfiles themselves
-.dockerignore
-*Dockerfile

--- a/README.md
+++ b/README.md
@@ -83,22 +83,6 @@ The PostgreSQL storage backend can optionally be enabled using `--features postg
 
 Copy `Settings-default.toml` to `Settings.toml` and edit per your requirements.
 
-### Docker
-
-#### Dev Container
-
-Build:
-
-`docker build --file=dev.Dockerfile --tag=geoengine:0.0.1 .`
-
-Execute:
-
-`docker container run --detach --name geoengine --publish 127.0.0.1:3030:8080 geoengine:0.0.1`
-
-Inspect the container:
-
-`docker exec -it geoengine bash`
-
 ## Troubleshooting
 
 ### Running out of memory map areas


### PR DESCRIPTION
In [ec29ded](https://github.com/geo-engine/geoengine/commit/ec29ded63e904c9fdd715b5447cfd0da02e9c9b6) the docker directory was removed.
This PR removes remaining references to docker.