### PR TITLE
pratt parser instead of prec climber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,3 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - https://github.com/geo-engine/geoengine/pull/614
   - The input parameters now include a field `column_names` to select vector columns/alias raster inputs
   - The output was changed to a map from column names/raster aliases to the respective statistics
+
+- The Expression uses a Pratt Parser instead of the previously used PrecClimber from `pest.rs`.
+
+  - https://github.com/geo-engine/geoengine/pull/641


### PR DESCRIPTION
- [X] I added an entry to [`CHANGELOG.md`](CHANGELOG.md) if knowledge of this change could be valuable to users.

---

Here is a brief summary of what I did:

Pest 2.4 deprecated PrecClimber for PrattParser. Since the functionality is equivalent, I adopted it to make it run through our CI again. PrecClimber would be removed in the future in any case.
