### PR TITLE
warn not fail on gdal pixel size missmatch

### DIFF
--- a/operators/src/source/gdal_source/mod.rs
+++ b/operators/src/source/gdal_source/mod.rs
@@ -896,16 +896,18 @@ where
     let gdal_dataset_geotransform = GdalDatasetGeoTransform::from(dataset.geo_transform()?);
     let (gdal_dataset_pixels_x, gdal_dataset_pixels_y) = dataset.raster_size();
 
-    debug_assert!(
-        approx_eq!(
-            GdalDatasetGeoTransform,
-            gdal_dataset_geotransform,
-            dataset_params.geo_transform
-        ),
-        "dataset geo transform is different to the one retrieved from GDAL: {:?} != {:?}",
+    if !approx_eq!(
+        GdalDatasetGeoTransform,
         gdal_dataset_geotransform,
         dataset_params.geo_transform
-    );
+    ) {
+        log::warn!(
+            "GdalDatasetParameters geo transform is different to the one retrieved from GDAL dataset: {:?} != {:?}",
+            dataset_params.geo_transform,
+            gdal_dataset_geotransform,
+        )
+    };
+
     debug_assert_eq!(gdal_dataset_pixels_x, dataset_params.width);
     debug_assert_eq!(gdal_dataset_pixels_y, dataset_params.height);
 

--- a/operators/src/source/gdal_source/mod.rs
+++ b/operators/src/source/gdal_source/mod.rs
@@ -905,7 +905,7 @@ where
             "GdalDatasetParameters geo transform is different to the one retrieved from GDAL dataset: {:?} != {:?}",
             dataset_params.geo_transform,
             gdal_dataset_geotransform,
-        )
+        );
     };
 
     debug_assert_eq!(gdal_dataset_pixels_x, dataset_params.width);


### PR DESCRIPTION
- [ ] I added an entry to [`CHANGELOG.md`](CHANGELOG.md) if knowledge of this change could be valuable to users.

---

Here is a brief summary of what I did:

changed the assert in gdal source where dataset pixel size and gdal pixelsize are compared into a warning. Somehow this is not always equal even if the number in the dataset is the number from gdalinfo.
