### PR TITLE
add GPX to default formats

### DIFF
--- a/Settings-default.toml
+++ b/Settings-default.toml
@@ -115,6 +115,7 @@ allowed_drivers = [
     "XLS",
     "XLSX",
     "Zarr",
+    "GPX",
 ]
 
 [session]


### PR DESCRIPTION
- [ ] I added an entry to [`CHANGELOG.md`](CHANGELOG.md) if knowledge of this change could be valuable to users.

---

Here is a brief summary of what I did:

<TEXT>
