### PR TITLE
Change signature algorithm of mock id token

### DIFF
--- a/services/src/pro/util/tests.rs
+++ b/services/src/pro/util/tests.rs
@@ -277,7 +277,7 @@ pub(in crate::pro) mod mock_oidc {
             .set_nonce(mock_token_config.nonce),
             &CoreRsaPrivateSigningKey::from_pem(TEST_PRIVATE_KEY, None)
                 .expect("Cannot create mock of RSA private key"),
-            CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha256,
+            CoreJwsSigningAlgorithm::RsaSsaPssSha256,
             Some(&AccessToken::new(
                 mock_token_config.access_for_id.to_string(),
             )),


### PR DESCRIPTION
- [ ] I added an entry to [`CHANGELOG.md`](CHANGELOG.md) if knowledge of this change could be valuable to users.

---

Here is a brief summary of what I did:

- Open ID Connect related tests failed, because the signing algorithm in the mock id token did not match the signing algorithm of the mock id provider.