### PR TITLE
Gbif provider fix: Column names not in quotation marks

### DIFF
--- a/services/src/datasets/external/gbif.rs
+++ b/services/src/datasets/external/gbif.rs
@@ -147,7 +147,10 @@ impl GbifDataProvider {
             filter = filters
                 .iter()
                 .enumerate()
-                .map(|(index, (column, _))| format!(" AND {column} = ${index}", index = index + 4))
+                .map(|(index, (column, _))| format!(
+                    r#" AND "{column}" = ${index}"#,
+                    index = index + 4
+                ))
                 .collect::<String>()
         );
 
@@ -202,7 +205,10 @@ impl GbifDataProvider {
             filter = filters
                 .iter()
                 .enumerate()
-                .map(|(index, (column, _))| format!(" AND {column} = ${index}", index = index + 3))
+                .map(|(index, (column, _))| format!(
+                    r#" AND "{column}" = ${index}"#,
+                    index = index + 3
+                ))
                 .collect::<String>()
         );
         let stmt = conn.prepare(query).await?;


### PR DESCRIPTION
- [ ] I added an entry to [`CHANGELOG.md`](CHANGELOG.md) if knowledge of this change could be valuable to users.

---

Here is a brief summary of what I did:

Column names were not put in quotation marks everywhere, so queries with column name "order" failed.
