### PR TITLE
enable gdal verbose errors in release build to detect file not found errors

### DIFF
--- a/operators/src/source/gdal_source/mod.rs
+++ b/operators/src/source/gdal_source/mod.rs
@@ -559,7 +559,8 @@ impl GdalRasterLoader {
             };
             let elapsed = start.elapsed();
             debug!(
-                "file not found -> returning error = {}, took: {:?}, file: {:?}",
+                "error opening dataset: {:?} -> returning error = {}, took: {:?}, file: {:?}",
+                error,
                 err_result.is_err(),
                 elapsed,
                 dataset_params.file_path

--- a/operators/src/util/gdal.rs
+++ b/operators/src/util/gdal.rs
@@ -104,7 +104,6 @@ pub fn gdal_open_dataset(path: &Path) -> Result<Dataset> {
 /// Opens a Gdal Dataset with the given `path` and `dataset_options`.
 /// Other crates should use this method for Gdal Dataset access as a workaround to avoid strange errors.
 pub fn gdal_open_dataset_ex(path: &Path, dataset_options: DatasetOptions) -> Result<Dataset> {
-    #[cfg(debug_assertions)]
     let dataset_options = {
         let mut dataset_options = dataset_options;
         dataset_options.open_flags |= gdal::GdalOpenFlags::GDAL_OF_VERBOSE_ERROR;


### PR DESCRIPTION
- [ ] I added an entry to [`CHANGELOG.md`](CHANGELOG.md) if knowledge of this change could be valuable to users.

---

Here is a brief summary of what I did:

<TEXT>
