### PR TITLE
add role id result type to open api spec

### DIFF
--- a/services/src/pro/handlers/users.rs
+++ b/services/src/pro/handlers/users.rs
@@ -529,8 +529,11 @@ pub struct AddRole {
     path = "/roles",
     request_body = AddRole,
     responses(
-        (status = 200, description = "Role was added")
-    ),
+        (status = 200, description = "Role was added", body = RoleId,
+        example = json!({
+            "id": "5b4466d2-8bab-4ed8-a182-722af3c80958"
+        })
+    )),
     security(
         ("session_token" = [])
     )


### PR DESCRIPTION
- [ ] I added an entry to [`CHANGELOG.md`](CHANGELOG.md) if knowledge of this change could be valuable to users.

---

Here is a brief summary of what I did:

<TEXT>
