### PR TITLE
allow name for datasets from workflow

### DIFF
--- a/services/src/datasets/create_from_workflow.rs
+++ b/services/src/datasets/create_from_workflow.rs
@@ -31,9 +31,11 @@ use utoipa::ToSchema;
 
 /// parameter for the dataset from workflow handler (body)
 #[derive(Clone, Debug, Deserialize, Serialize, ToSchema)]
-#[schema(example = json!({"name": "foo", "description": null, "query": {"spatialBounds": {"upperLeftCoordinate": {"x": -10.0, "y": 80.0}, "lowerRightCoordinate": {"x": 50.0, "y": 20.0}}, "timeInterval": {"start": 1_388_534_400_000_i64, "end": 1_388_534_401_000_i64}, "spatialResolution": {"x": 0.1, "y": 0.1}}}))]
+#[schema(example = json!({"name": "foo", "displayName": "a new dataset", "description": null, "query": {"spatialBounds": {"upperLeftCoordinate": {"x": -10.0, "y": 80.0}, "lowerRightCoordinate": {"x": 50.0, "y": 20.0}}, "timeInterval": {"start": 1_388_534_400_000_i64, "end": 1_388_534_401_000_i64}, "spatialResolution": {"x": 0.1, "y": 0.1}}}))]
+#[serde(rename_all = "camelCase")]
 pub struct RasterDatasetFromWorkflow {
-    pub name: String,
+    pub name: Option<DatasetName>,
+    pub display_name: String,
     pub description: Option<String>,
     pub query: RasterQueryRectangle,
     #[schema(default = default_as_cog)]
@@ -248,8 +250,8 @@ async fn create_dataset<C: SessionContext>(
 
     let dataset_definition = DatasetDefinition {
         properties: AddDataset {
-            name: None,
-            display_name: info.name,
+            name: info.name,
+            display_name: info.display_name,
             description: info.description.unwrap_or_default(),
             source_operator: "GdalSource".to_owned(),
             symbology: None,  // TODO add symbology?

--- a/services/src/handlers/layers.rs
+++ b/services/src/handlers/layers.rs
@@ -628,7 +628,8 @@ async fn layer_to_dataset<C: ApplicationContext>(
     };
 
     let from_workflow = RasterDatasetFromWorkflow {
-        name: layer.name,
+        name: None,
+        display_name: layer.name,
         description: Some(layer.description),
         query: qr,
         as_cog: true,

--- a/services/src/handlers/workflows.rs
+++ b/services/src/handlers/workflows.rs
@@ -1370,7 +1370,7 @@ mod tests {
             .append_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))
             .set_payload(
                 r#"{
-                "name": "foo",
+                "displayName": "foo",
                 "description": null,
                 "query": {
                     "spatialBounds": {


### PR DESCRIPTION
- [ ] I added an entry to [`CHANGELOG.md`](CHANGELOG.md) if knowledge of this change could be valuable to users.

---

Here is a brief summary of what I did:

create dataset from worklfow now has the option to set a name for the new dataset
