### PR TITLE
fix async file logger and more complex filters

### DIFF
--- a/Settings-default.toml
+++ b/Settings-default.toml
@@ -47,7 +47,11 @@ path = "upload"
 
 [logging]
 # Minimum log level. Can be one of error, warn, info, debug, trace
-# or a more detailed spec. See https://docs.rs/flexi_logger/0.17.1/flexi_logger/struct.LogSpecification.html.
+# Console and file logging uses the tokio tracing crate.
+# The spec defined here is parsed using the tracing_subscriber::EnvFilter. This allows to use complex filter expressions.
+# For example `info,geoengine_services=debug` will log all info messages and all debug messages from the "geoengine_services" crate.
+# To get all info messages, all debug messages from crates prefixed with "geoengine", and all trace messages from "geoengine_operators" use: `info,geoengine=debug,geoengine_operators=trace`.
+# See https://docs.rs/tracing-subscriber/latest/tracing_subscriber/ for more information.
 log_spec = "info"
 
 # Whether the logs should be also written to files.

--- a/services/src/bin/main.rs
+++ b/services/src/bin/main.rs
@@ -1,14 +1,13 @@
-use flexi_logger::writers::FileLogWriter;
+use flexi_logger::writers::{FileLogWriter, FileLogWriterHandle};
 use flexi_logger::{Age, Cleanup, Criterion, FileSpec, Naming, WriteMode};
 use geoengine_services::error::Result;
 use geoengine_services::util::config;
 use geoengine_services::util::config::get_config_element;
-use std::str::FromStr;
-use tracing::metadata::LevelFilter;
 use tracing::Subscriber;
 use tracing_subscriber::field::RecordFields;
 use tracing_subscriber::fmt::format::{DefaultFields, Writer};
 use tracing_subscriber::fmt::FormatFields;
+use tracing_subscriber::layer::Filter;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::Layer;
@@ -22,26 +21,26 @@ async fn main() {
 pub async fn start_server() -> Result<()> {
     reroute_gdal_logging();
     let logging_config: config::Logging = get_config_element()?;
-    // create a filter for the log message level
-    let level_filter = LevelFilter::from_str(&logging_config.log_spec).unwrap();
 
-    // get a new tracing subscriber registry to add all log and tracing layers to
-    let registry = tracing_subscriber::Registry::default();
+    // create a filter for the log message level in console output
+    let console_filter = EnvFilter::try_new(&logging_config.log_spec).unwrap();
 
     // create a log layer for output to the console and add it to the registry
-    let registry = registry.with(console_layer().with_filter(level_filter));
+    let registry = registry.with(console_layer_with_filter(console_filter));
+
+    // create a filter for the log message level in file output. Since the console_filter is not copy or clone, we have to create a new one. TODO: allow a different log level for file output.
+    let file_filter = EnvFilter::try_new(&logging_config.log_spec).unwrap();
 
     // create a log layer for output to a file and add it to the registry
-    let file_layer = if logging_config.log_to_file {
-        Some(
-            file_layer(
-                &logging_config.filename_prefix,
-                logging_config.log_directory.as_deref(),
-            )
-            .with_filter(level_filter),
-        )
+    let (file_layer, _fw_drop_guard) = if logging_config.log_to_file {
+        let (file_layer, fw_drop_guard) = file_layer_with_filter(
+            &logging_config.filename_prefix,
+            logging_config.log_directory.as_deref(),
+            level_filter,
+        );
+        (Some(file_layer), Some(fw_drop_guard))
     } else {
-        None
+        (None, None)
     };
     let registry = registry.with(file_layer);
 
@@ -52,29 +51,33 @@ pub async fn start_server() -> Result<()> {
 
 #[cfg(feature = "pro")]
 pub async fn start_server() -> Result<()> {
+    use tracing_subscriber::EnvFilter;
+
     reroute_gdal_logging();
     let logging_config: config::Logging = get_config_element()?;
 
     // get a new tracing subscriber registry to add all log and tracing layers to
     let registry = tracing_subscriber::Registry::default();
 
-    // create a filter for the log message level
-    let level_filter = LevelFilter::from_str(&logging_config.log_spec).unwrap();
+    // create a filter for the log message level in console output
+    let console_filter = EnvFilter::try_new(&logging_config.log_spec).unwrap();
 
     // create a log layer for output to the console and add it to the registry
-    let registry = registry.with(console_layer().with_filter(level_filter));
+    let registry = registry.with(console_layer_with_filter(console_filter));
+
+    // create a filter for the log message level in file output. Since the console_filter is not copy or clone, we have to create a new one. TODO: allow a different log level for file output.
+    let file_filter = EnvFilter::try_new(&logging_config.log_spec).unwrap();
 
     // create a log layer for output to a file and add it to the registry
-    let file_layer = if logging_config.log_to_file {
-        Some(
-            file_layer(
-                &logging_config.filename_prefix,
-                logging_config.log_directory.as_deref(),
-            )
-            .with_filter(level_filter),
-        )
+    let (file_layer, _fw_drop_guard) = if logging_config.log_to_file {
+        let (file_layer, fw_drop_guard) = file_layer_with_filter(
+            &logging_config.filename_prefix,
+            logging_config.log_directory.as_deref(),
+            file_filter,
+        );
+        (Some(file_layer), Some(fw_drop_guard))
     } else {
-        None
+        (None, None)
     };
     let registry = registry.with(file_layer);
 
@@ -112,16 +115,18 @@ where
     Ok(opentelemetry)
 }
 
-fn console_layer<S>() -> impl Layer<S>
+fn console_layer_with_filter<S, F: Filter<S> + 'static>(filter: F) -> impl Layer<S>
 where
     S: Subscriber,
     for<'a> S: LookupSpan<'a>,
 {
     tracing_subscriber::fmt::layer()
+        .pretty()
         .with_file(false)
         .with_target(true)
         .with_ansi(true)
-        .with_writer(std::io::stderr)
+        .with_writer(std::io::stdout)
+        .with_filter(filter)
 }
 
 // we use a custom formatter because there are still format flags within spans even when `with_ansi` is false due to bug: https://github.com/tokio-rs/tracing/issues/1817
@@ -137,7 +142,11 @@ impl<'writer> FormatFields<'writer> for FileFormatterWorkaround {
     }
 }
 
-fn file_layer<S>(filename_prefix: &str, log_directory: Option<&str>) -> impl Layer<S>
+fn file_layer_with_filter<S, F: Filter<S> + 'static>(
+    filename_prefix: &str,
+    log_directory: Option<&str>,
+    filter: F,
+) -> (impl Layer<S>, FileLogWriterHandle)
 where
     S: Subscriber,
     for<'a> S: LookupSpan<'a>,
@@ -153,9 +162,9 @@ where
     // Thus, we use UTC time instead.
     flexi_logger::DeferredNow::force_utc();
 
-    let (file_writer, _fw_handle) = FileLogWriter::builder(file_spec)
+    let (file_writer, fw_handle) = FileLogWriter::builder(file_spec)
         // TODO: the mode should be Async but somehow that never writes anything to the file
-        .write_mode(WriteMode::BufferAndFlush)
+        .write_mode(WriteMode::Async)
         .append()
         .rotate(
             Criterion::Age(Age::Day),
@@ -165,13 +174,15 @@ where
         .try_build_with_handle()
         .unwrap();
 
-    tracing_subscriber::fmt::layer()
+    let layer = tracing_subscriber::fmt::layer()
         .with_file(false)
         .with_target(true)
         // we use a custom formatter because there are still format flags within spans even when `with_ansi` is false due to bug: https://github.com/tokio-rs/tracing/issues/1817
         .fmt_fields(FileFormatterWorkaround(DefaultFields::default()))
         .with_ansi(false)
         .with_writer(move || file_writer.clone())
+        .with_filter(filter);
+    (layer, fw_handle)
 }
 
 /// We install a GDAL error handler that logs all messages with our log macros.

--- a/services/src/bin/main.rs
+++ b/services/src/bin/main.rs
@@ -10,6 +10,7 @@ use tracing_subscriber::fmt::FormatFields;
 use tracing_subscriber::layer::Filter;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Layer;
 
 #[tokio::main]
@@ -21,6 +22,9 @@ async fn main() {
 pub async fn start_server() -> Result<()> {
     reroute_gdal_logging();
     let logging_config: config::Logging = get_config_element()?;
+
+    // get a new tracing subscriber registry to add all log and tracing layers to
+    let registry = tracing_subscriber::Registry::default();
 
     // create a filter for the log message level in console output
     let console_filter = EnvFilter::try_new(&logging_config.log_spec).unwrap();
@@ -36,7 +40,7 @@ pub async fn start_server() -> Result<()> {
         let (file_layer, fw_drop_guard) = file_layer_with_filter(
             &logging_config.filename_prefix,
             logging_config.log_directory.as_deref(),
-            level_filter,
+            file_filter,
         );
         (Some(file_layer), Some(fw_drop_guard))
     } else {
@@ -51,8 +55,6 @@ pub async fn start_server() -> Result<()> {
 
 #[cfg(feature = "pro")]
 pub async fn start_server() -> Result<()> {
-    use tracing_subscriber::EnvFilter;
-
     reroute_gdal_logging();
     let logging_config: config::Logging = get_config_element()?;
 

--- a/services/src/bin/main.rs
+++ b/services/src/bin/main.rs
@@ -165,7 +165,6 @@ where
     flexi_logger::DeferredNow::force_utc();
 
     let (file_writer, fw_handle) = FileLogWriter::builder(file_spec)
-        // TODO: the mode should be Async but somehow that never writes anything to the file
         .write_mode(WriteMode::Async)
         .append()
         .rotate(

--- a/services/src/bin/main.rs
+++ b/services/src/bin/main.rs
@@ -127,7 +127,7 @@ where
         .with_file(false)
         .with_target(true)
         .with_ansi(true)
-        .with_writer(std::io::stdout)
+        .with_writer(std::io::stderr)
         .with_filter(filter)
 }
 


### PR DESCRIPTION
- [ ] I added an entry to [`CHANGELOG.md`](CHANGELOG.md) if knowledge of this change could be valuable to users.

---

Here is a brief summary of what I did:

- The file logging layer dropped the drop guard on creation. This causes the async file writer to drop also and results in empty log files.

- Additionaly, the log spec now uses EnvFilter which allows to use more complex filter e.g. per crate.