### PR TITLE
pixel based query rects for raster requests

### DIFF
--- a/Settings-test.toml
+++ b/Settings-test.toml
@@ -2,7 +2,7 @@
 host = "localhost"
 port = 5432
 database = "geoengine"
-schema = "pg_temp" # we need the right to create new schemata for tests
+schema = "pg_temp"     # we need the right to create new schemata for tests
 user = "geoengine"
 password = "geoengine"
 
@@ -10,10 +10,10 @@ password = "geoengine"
 raster_data_root_path = "../test_data/raster" # relative to sub crate directory for tests
 
 [raster.tiling_specification]
-    origin_coordinate_x = 0.0
-    origin_coordinate_y = 0.0
-    tile_shape_pixels_x = 512
-    tile_shape_pixels_y = 512
+origin_coordinate_x = 0.0
+origin_coordinate_y = 0.0
+tile_shape_pixels_x = 512
+tile_shape_pixels_y = 512
 
 [upload]
 path = "test_upload"
@@ -27,7 +27,7 @@ issuer = ""
 client_id = ""
 client_secret = ""
 redirect_uri = ""
-scopes = [ ]
+scopes = []
 
 [user]
 admin_email = "admin@localhost"
@@ -36,7 +36,7 @@ admin_password = "admin"
 [quota]
 mode = "check"
 default_available_quota = 9999
-increment_quota_buffer_size = 0 # number of quota updates to buffer before sending them to the database
+increment_quota_buffer_size = 0             # number of quota updates to buffer before sending them to the database
 increment_quota_buffer_timeout_seconds = 60 # number of seconds after which the quota updates are sent to the database
 
 [cache]
@@ -45,4 +45,3 @@ enabled = false
 cache_size_in_mb = 1_000 # 1 GB
 # storage limit for collecting query results before insertion into the cache in 
 landing_zone_ratio = 0.1 # 10% of total cache size
-

--- a/datatypes/src/operations/reproject.rs
+++ b/datatypes/src/operations/reproject.rs
@@ -3,7 +3,8 @@ use crate::{
     primitives::{
         AxisAlignedRectangle, Coordinate2D, Line, MultiLineString, MultiLineStringAccess,
         MultiLineStringRef, MultiPoint, MultiPointAccess, MultiPointRef, MultiPolygon,
-        MultiPolygonAccess, MultiPolygonRef, QueryRectangle, SpatialBounded, SpatialResolution,
+        MultiPolygonAccess, MultiPolygonRef, SpatialBounded, SpatialQueryRectangle,
+        SpatialResolution,
     },
     spatial_reference::SpatialReference,
     util::Result,
@@ -451,19 +452,18 @@ pub fn project_coordinates_fail_tolerant<P: CoordinateProjection>(
 
 /// this method performs the transformation of a query rectangle in `target` projection
 /// to a new query rectangle with coordinates in the `source` projection
-pub fn reproject_query<S: AxisAlignedRectangle>(
-    query: QueryRectangle<S>,
+pub fn reproject_spatial_query<S: AxisAlignedRectangle>(
+    query: SpatialQueryRectangle<S>,
     source: SpatialReference,
     target: SpatialReference,
-) -> Result<Option<QueryRectangle<S>>> {
+) -> Result<Option<SpatialQueryRectangle<S>>> {
     let (Some(s_bbox), Some(p_bbox)) = reproject_and_unify_bbox(query.spatial_bounds, target, source)? else { return Ok(None); };
 
     let p_spatial_resolution =
         suggest_pixel_size_from_diag_cross_projected(s_bbox, p_bbox, query.spatial_resolution)?;
-    Ok(Some(QueryRectangle {
+    Ok(Some(SpatialQueryRectangle {
         spatial_bounds: p_bbox,
         spatial_resolution: p_spatial_resolution,
-        time_interval: query.time_interval,
     }))
 }
 

--- a/datatypes/src/primitives/mod.rs
+++ b/datatypes/src/primitives/mod.rs
@@ -37,7 +37,9 @@ pub use multi_point::{MultiPoint, MultiPointAccess, MultiPointRef};
 pub use multi_polygon::{MultiPolygon, MultiPolygonAccess, MultiPolygonRef};
 pub use no_geometry::NoGeometry;
 pub use query_rectangle::{
-    PlotQueryRectangle, QueryRectangle, RasterQueryRectangle, VectorQueryRectangle,
+    PlotQueryRectangle, PlotSpatialQueryRectangle, QueryRectangle, RasterQueryRectangle,
+    RasterSpatialQueryRectangle, SpatialGridQueryRectangle, SpatialQueryRectangle,
+    VectorQueryRectangle, VectorSpatialQueryRectangle,
 };
 pub use spatial_partition::{
     partitions_extent, AxisAlignedRectangle, SpatialPartition2D, SpatialPartitioned,

--- a/datatypes/src/primitives/query_rectangle.rs
+++ b/datatypes/src/primitives/query_rectangle.rs
@@ -1,34 +1,183 @@
+use crate::raster::{GeoTransform, GridBoundingBox2D, GridBounds};
+
 use super::{
-    AxisAlignedRectangle, BoundingBox2D, SpatialPartition2D, SpatialPartitioned, SpatialResolution,
-    TimeInterval,
+    AxisAlignedRectangle, BoundingBox2D, Coordinate2D, SpatialBounded, SpatialPartition2D,
+    SpatialPartitioned, SpatialResolution, TimeInterval,
 };
 use serde::{Deserialize, Serialize};
 
 /// A spatio-temporal rectangle with a specified resolution
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct QueryRectangle<SpatialBounds: AxisAlignedRectangle> {
-    pub spatial_bounds: SpatialBounds,
+pub struct QueryRectangle<SpatialQuery> {
+    pub spatial_query: SpatialQuery,
     pub time_interval: TimeInterval,
+}
+
+impl<SpatialQuery: Copy> QueryRectangle<SpatialQuery> {
+    pub fn spatial_query(&self) -> SpatialQuery {
+        self.spatial_query
+    }
+
+    pub fn temporal_query(&self) -> TimeInterval {
+        self.time_interval
+    }
+
+    pub fn spatial_query_mut(&mut self) -> &mut SpatialQuery {
+        &mut self.spatial_query
+    }
+
+    pub fn temporal_query_mut(&mut self) -> &mut TimeInterval {
+        &mut self.time_interval
+    }
+}
+
+pub type VectorQueryRectangle = QueryRectangle<SpatialQueryRectangle<BoundingBox2D>>;
+pub type RasterQueryRectangle = QueryRectangle<SpatialGridQueryRectangle>;
+pub type PlotQueryRectangle = QueryRectangle<SpatialQueryRectangle<BoundingBox2D>>;
+
+impl<S> QueryRectangle<SpatialQueryRectangle<S>>
+where
+    S: SpatialBounded,
+{
+    pub fn new(spatial_bounds: SpatialQueryRectangle<S>, time_interval: TimeInterval) -> Self {
+        Self {
+            spatial_query: spatial_bounds,
+            time_interval,
+        }
+    }
+
+    /// Creates a new `QueryRectangle` from a `BoundingBox2D`, a `TimeInterval`, and a `SpatialResolution`.
+    pub fn with_bounds_and_resolution(
+        spatial_bounds: S,
+        time_interval: TimeInterval,
+        spatial_resolution: SpatialResolution,
+    ) -> Self {
+        Self {
+            spatial_query: SpatialQueryRectangle {
+                spatial_bounds,
+                spatial_resolution,
+            },
+            time_interval,
+        }
+    }
+}
+
+impl QueryRectangle<SpatialGridQueryRectangle> {
+    /// Creates a new `QueryRectangle` that describes the requested grid.
+    /// The spatial query is defined by a `SpatialGridQueryRectangle`, which is derived from a `SpatialPartition2D`, a `SpatialResolution` and a origin `Coordinate2D`.
+    /// The temporal query is defined by a `TimeInterval`.
+    /// NOTE: If the distance between the upper left of the spatial partition and the origin coordinate is not at a multiple of the spatial resolution, the grid bounds will be shifted.
+    pub fn with_partition_and_resolution_and_origin(
+        spatial_partition: SpatialPartition2D,
+        spatial_resolution: SpatialResolution,
+        origin_coordinate: Coordinate2D,
+        time_interval: TimeInterval,
+    ) -> Self {
+        Self::new(
+            SpatialGridQueryRectangle::with_partition_and_resolution_and_origin(
+                spatial_partition,
+                spatial_resolution,
+                origin_coordinate,
+            ),
+            time_interval,
+        )
+    }
+
+    /// Creates a new `QueryRectangle` that describes the requested grid.
+    /// The spatial query is derived from a vector query rectangle and a grid origin.
+    /// The temporal query is defined by a `TimeInterval`.
+    /// NOTE: If the distance between the upper left of the spatial partition and the origin coordinate is not at a multiple of the spatial resolution, the grid bounds will be shifted.
+    pub fn with_vector_query_and_grid_origin(
+        vector_query: VectorQueryRectangle,
+        grid_origin: Coordinate2D,
+    ) -> Self {
+        Self::new(
+            SpatialGridQueryRectangle::with_vector_query_and_grid_origin(
+                vector_query.spatial_query(),
+                grid_origin,
+            ),
+            vector_query.time_interval,
+        )
+    }
+
+    /// Creates a new `QueryRectangle` that describes the requested grid.
+    /// The spatial query is defined by a `SpatialGridQueryRectangle`, which is derived from a `SpatialPartition2D` and a `SpatialResolution`.
+    /// The temporal query is defined by a `TimeInterval`.
+    pub fn with_partition_and_resolution(
+        spatial_partition: SpatialPartition2D,
+        spatial_resolution: SpatialResolution,
+        time_interval: TimeInterval,
+    ) -> Self {
+        Self::new(
+            SpatialGridQueryRectangle::_with_partition_and_resolution(
+                spatial_partition,
+                spatial_resolution,
+            ),
+            time_interval,
+        )
+    }
+
+    pub fn with_grid_bounds_and_resolution(
+        grid_bounds: GridBoundingBox2D,
+        geo_transform: GeoTransform,
+        time_interval: TimeInterval,
+    ) -> Self {
+        Self::new(
+            SpatialGridQueryRectangle::new(geo_transform, grid_bounds),
+            time_interval,
+        )
+    }
+
+    /// Creates a new `QueryRectangle` with a spatial grid query defined by a `SpatialGridQueryRectangle` and a temporal query defined by a `TimeInterval`.
+    pub fn new(spatial_bounds: SpatialGridQueryRectangle, time_interval: TimeInterval) -> Self {
+        Self {
+            spatial_query: spatial_bounds,
+            time_interval,
+        }
+    }
+}
+
+pub type RasterSpatialQueryRectangle = SpatialGridQueryRectangle;
+pub type VectorSpatialQueryRectangle = SpatialQueryRectangle<BoundingBox2D>;
+pub type PlotSpatialQueryRectangle = SpatialQueryRectangle<BoundingBox2D>;
+
+/// A spatio-temporal rectangle with a specified resolution
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SpatialQueryRectangle<SpatialBounds> {
+    pub spatial_bounds: SpatialBounds,
     pub spatial_resolution: SpatialResolution,
 }
 
-pub type VectorQueryRectangle = QueryRectangle<BoundingBox2D>;
-pub type RasterQueryRectangle = QueryRectangle<SpatialPartition2D>;
-pub type PlotQueryRectangle = QueryRectangle<BoundingBox2D>;
+impl SpatialBounded for SpatialQueryRectangle<BoundingBox2D> {
+    fn spatial_bounds(&self) -> BoundingBox2D {
+        self.spatial_bounds
+    }
+}
 
-impl SpatialPartitioned for QueryRectangle<BoundingBox2D> {
+impl SpatialPartitioned for SpatialQueryRectangle<BoundingBox2D> {
     fn spatial_partition(&self) -> SpatialPartition2D {
         SpatialPartition2D::with_bbox_and_resolution(self.spatial_bounds, self.spatial_resolution)
     }
 }
 
-impl SpatialPartitioned for QueryRectangle<SpatialPartition2D> {
+impl SpatialPartitioned for SpatialQueryRectangle<SpatialPartition2D> {
     fn spatial_partition(&self) -> SpatialPartition2D {
         self.spatial_bounds
     }
 }
 
+impl From<RasterQueryRectangle> for VectorQueryRectangle {
+    fn from(value: RasterQueryRectangle) -> Self {
+        Self::with_bounds_and_resolution(
+            value.spatial_query().spatial_bounds(),
+            value.time_interval,
+            value.spatial_query().geo_transform.spatial_resolution(),
+        )
+    }
+}
+
+/*
 impl From<QueryRectangle<BoundingBox2D>> for QueryRectangle<SpatialPartition2D> {
     fn from(value: QueryRectangle<BoundingBox2D>) -> Self {
         Self {
@@ -36,5 +185,115 @@ impl From<QueryRectangle<BoundingBox2D>> for QueryRectangle<SpatialPartition2D> 
             time_interval: value.time_interval,
             spatial_resolution: value.spatial_resolution,
         }
+    }
+}
+*/
+
+/// A spatio-temporal grid query with a geotransform and a size in pixels.
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpatialGridQueryRectangle {
+    pub geo_transform: GeoTransform,
+    pub grid_bounds: GridBoundingBox2D,
+}
+
+impl SpatialPartitioned for SpatialGridQueryRectangle {
+    fn spatial_partition(&self) -> SpatialPartition2D {
+        self.geo_transform.grid_to_spatial_bounds(&self.grid_bounds)
+    }
+}
+
+impl SpatialBounded for SpatialGridQueryRectangle {
+    fn spatial_bounds(&self) -> BoundingBox2D {
+        self.spatial_partition().as_bbox()
+    }
+}
+
+impl SpatialGridQueryRectangle {
+    pub fn new(geo_transform: GeoTransform, grid_bounds: GridBoundingBox2D) -> Self {
+        Self {
+            geo_transform,
+            grid_bounds,
+        }
+    }
+
+    pub fn spatial_resolution(&self) -> SpatialResolution {
+        self.geo_transform.spatial_resolution()
+    }
+
+    pub fn origin_coordinate(&self) -> Coordinate2D {
+        self.geo_transform.origin_coordinate()
+    }
+
+    /// Creates a new `SpatialGridQueryRectangle` from a spatial partition and a spatial resolution.
+    /// The origin of the grid is set to the upper left corner of the spatial partition.
+    /// TODO: we may need to replace this with a version that supports positive and negative (pixel) resolutions.
+    fn _with_partition_and_resolution(
+        spatial_partition: SpatialPartition2D,
+        spatial_resolution: SpatialResolution,
+    ) -> Self {
+        // we need to create a geo transform here. There might be a better way to do this.
+        debug_assert!(spatial_resolution.x > 0.0);
+        debug_assert!(spatial_resolution.y > 0.0);
+
+        let geo_transform = GeoTransform::new(
+            spatial_partition.upper_left(),
+            spatial_resolution.x,
+            spatial_resolution.y.abs() * -1.0,
+        );
+
+        // Once we have the geo transform, we can calculate the grid bounds.
+        let grid_bounds = geo_transform.spatial_to_grid_bounds(&spatial_partition);
+
+        Self {
+            geo_transform,
+            grid_bounds,
+        }
+    }
+
+    /// Creates a new `SpatialGridQueryRectangle` from a spatial partition and a spatial resolution.
+    /// The origin of the grid is set to the provided origin coordinate.
+    /// NOTE: If the distance between the upper left of the spatial partition and the origin coordinate is not at a multiple of the spatial resolution, the grid bounds will be shifted.
+    pub fn with_partition_and_resolution_and_origin(
+        spatial_partition: SpatialPartition2D,
+        spatial_resolution: SpatialResolution,
+        origin_coordinate: Coordinate2D,
+    ) -> Self {
+        let SpatialGridQueryRectangle {
+            geo_transform,
+            grid_bounds,
+        } = Self::_with_partition_and_resolution(spatial_partition, spatial_resolution);
+
+        let offset = geo_transform.coordinate_to_grid_idx_2d(origin_coordinate);
+
+        let shifted_grid_bounds = GridBoundingBox2D::new(
+            grid_bounds.min_index() - offset,
+            grid_bounds.max_index() - offset,
+        )
+        .expect(
+            "shifting the grid bounds must not fail since the offset is identical for min and max",
+        );
+
+        let shifted_geo_transform = GeoTransform::new(
+            origin_coordinate,
+            geo_transform.x_pixel_size(),
+            geo_transform.y_pixel_size(),
+        );
+
+        Self {
+            geo_transform: shifted_geo_transform,
+            grid_bounds: shifted_grid_bounds,
+        }
+    }
+
+    pub fn with_vector_query_and_grid_origin(
+        vector_spatial_query: VectorSpatialQueryRectangle,
+        origin_coordinate: Coordinate2D,
+    ) -> Self {
+        Self::with_partition_and_resolution_and_origin(
+            vector_spatial_query.spatial_partition(),
+            vector_spatial_query.spatial_resolution,
+            origin_coordinate,
+        )
     }
 }

--- a/datatypes/src/raster/geo_transform.rs
+++ b/datatypes/src/raster/geo_transform.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use serde::{de, Deserialize, Deserializer, Serialize};
 
-use super::{GridBoundingBox2D, GridIdx, GridIdx2D};
+use super::{GridBoundingBox2D, GridBounds, GridIdx, GridIdx2D};
 
 /// This is a typedef for the `GDAL GeoTransform`. It represents an affine transformation matrix.
 pub type GdalGeoTransform = [f64; 6];
@@ -221,6 +221,17 @@ impl GeoTransform {
         }
 
         Ok(unchecked)
+    }
+
+    pub fn grid_to_spatial_bounds(&self, grid_bounds: &GridBoundingBox2D) -> SpatialPartition2D {
+        let ul = self.grid_idx_to_pixel_upper_left_coordinate_2d(grid_bounds.min_index());
+        let lr = self.grid_idx_to_pixel_upper_left_coordinate_2d(grid_bounds.max_index() + 1);
+
+        SpatialPartition2D::new_unchecked(ul, lr)
+    }
+
+    pub fn origin_coordinate(&self) -> Coordinate2D {
+        self.origin_coordinate
     }
 }
 

--- a/datatypes/src/raster/grid_bounds.rs
+++ b/datatypes/src/raster/grid_bounds.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use snafu::ensure;
 
 use crate::{error, util::Result};
@@ -7,7 +8,8 @@ use super::{
     GridSize, GridSpaceToLinearSpace,
 };
 
-#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone)]
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
+/// A bounding box for a grid where the min and max values are inclusive
 pub struct GridBoundingBox<A>
 where
     A: AsRef<[isize]>,
@@ -326,6 +328,82 @@ where
     }
 }
 
+impl GridContains<GridBoundingBox2D> for GridBoundingBox2D {
+    fn contains(&self, other: &GridBoundingBox2D) -> bool {
+        let [self_y_min, self_x_min] = self.min;
+        let [other_y_min, other_x_min] = other.min;
+
+        let [self_y_max, self_x_max] = self.max;
+        let [other_y_max, other_x_max] = other.max;
+
+        self_y_min <= other_y_min
+            && self_x_min <= other_x_min
+            && self_y_max >= other_y_max
+            && self_x_max >= other_x_max
+    }
+}
+
+pub trait GridBoundingBoxExt {
+    fn extend(&mut self, other: &Self);
+
+    #[must_use]
+    fn extended(&self, other: &Self) -> Self
+    where
+        Self: Sized + Clone,
+    {
+        let mut extended = self.clone();
+        extended.extend(other);
+        extended
+    }
+}
+
+impl GridBoundingBoxExt for GridBoundingBox1D {
+    fn extend(&mut self, other: &Self) {
+        let [self_x_min] = self.min;
+        let [other_x_min] = other.min;
+
+        let [self_x_max] = self.max;
+        let [other_x_max] = other.max;
+
+        self.min = [self_x_min.min(other_x_min)];
+        self.max = [self_x_max.max(other_x_max)];
+    }
+}
+
+impl GridBoundingBoxExt for GridBoundingBox2D {
+    fn extend(&mut self, other: &Self) {
+        let [self_y_min, self_x_min] = self.min;
+        let [other_y_min, other_x_min] = other.min;
+
+        let [self_y_max, self_x_max] = self.max;
+        let [other_y_max, other_x_max] = other.max;
+
+        self.min = [self_y_min.min(other_y_min), self_x_min.min(other_x_min)];
+        self.max = [self_y_max.max(other_y_max), self_x_max.max(other_x_max)];
+    }
+}
+
+impl GridBoundingBoxExt for GridBoundingBox3D {
+    fn extend(&mut self, other: &Self) {
+        let [self_z_min, self_y_min, self_x_min] = self.min;
+        let [other_z_min, other_y_min, other_x_min] = other.min;
+
+        let [self_z_max, self_y_max, self_x_max] = self.max;
+        let [other_z_max, other_y_max, other_x_max] = other.max;
+
+        self.min = [
+            self_z_min.min(other_z_min),
+            self_y_min.min(other_y_min),
+            self_x_min.min(other_x_min),
+        ];
+        self.max = [
+            self_z_max.max(other_z_max),
+            self_y_max.max(other_y_max),
+            self_x_max.max(other_x_max),
+        ];
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -460,5 +538,37 @@ mod tests {
         let l2 = a.linear_space_index_unchecked([2, 2, 2]);
         assert_eq!(l2, 1 * 42 * 42 + 1 * 42 + 1);
         assert_eq!(a.grid_idx_unchecked(l2), [2, 2, 2].into());
+    }
+
+    #[test]
+    fn grid_bounding_box_2d_contains() {
+        let a = GridBoundingBox::new([1, 1], [42, 42]).unwrap();
+        let b = GridBoundingBox::new([2, 2], [41, 41]).unwrap();
+        assert!(a.contains(&b));
+        assert!(!b.contains(&a));
+    }
+
+    #[test]
+    fn extend_1d() {
+        let mut a = GridBoundingBox::new([1], [42]).unwrap();
+        let b = GridBoundingBox::new([2], [69]).unwrap();
+        a.extend(&b);
+        assert_eq!(a, GridBoundingBox::new([1], [69]).unwrap());
+    }
+
+    #[test]
+    fn extend_2d() {
+        let mut a = GridBoundingBox::new([1, 2], [42, 69]).unwrap();
+        let b = GridBoundingBox::new([2, 1], [69, 42]).unwrap();
+        a.extend(&b);
+        assert_eq!(a, GridBoundingBox::new([1, 1], [69, 69]).unwrap());
+    }
+
+    #[test]
+    fn extend_3d() {
+        let mut a = GridBoundingBox::new([1, 3, 2], [42, 69, 666]).unwrap();
+        let b = GridBoundingBox::new([3, 2, 1], [69, 666, 42]).unwrap();
+        a.extend(&b);
+        assert_eq!(a, GridBoundingBox::new([1, 2, 1], [69, 666, 666]).unwrap());
     }
 }

--- a/datatypes/src/raster/grid_traits.rs
+++ b/datatypes/src/raster/grid_traits.rs
@@ -82,6 +82,10 @@ where
 pub trait GridIntersection<Rhs = Self, Out = Self> {
     // Returns true if Self intesects Rhs
     fn intersection(&self, other: &Rhs) -> Option<Out>;
+
+    fn intersects(&self, other: &Rhs) -> bool {
+        self.intersection(other).is_some()
+    }
 }
 
 /// Provides the methods needed to map an n-dimensional `GridIdx` to linear space.

--- a/datatypes/src/raster/mod.rs
+++ b/datatypes/src/raster/mod.rs
@@ -8,7 +8,7 @@ pub use self::grid::{
     GridShape3D,
 };
 pub use self::grid_bounds::{
-    GridBoundingBox, GridBoundingBox1D, GridBoundingBox2D, GridBoundingBox3D,
+    GridBoundingBox, GridBoundingBox1D, GridBoundingBox2D, GridBoundingBox3D, GridBoundingBoxExt,
 };
 pub use self::grid_index::{GridIdx, GridIdx1D, GridIdx2D, GridIdx3D};
 pub use self::grid_or_empty::{GridOrEmpty, GridOrEmpty1D, GridOrEmpty2D, GridOrEmpty3D};

--- a/datatypes/src/raster/raster_tile.rs
+++ b/datatypes/src/raster/raster_tile.rs
@@ -35,7 +35,7 @@ pub type MaterializedRasterTile3D<T> = MaterializedRasterTile<GridShape3D, T>;
 pub struct BaseTile<G> {
     /// The `TimeInterval` where this tile is valid.
     pub time: TimeInterval,
-    /// The tile position is the position of the tile in the gird of tiles with origin at the origin of the global_geo_transform.
+    /// The tile position is the position of the tile in the grid of tiles with origin at the origin of the global_geo_transform.
     /// This is NOT a pixel position inside the tile.
     pub tile_position: GridIdx2D,
     /// The global geotransform to transform pixels into geographic coordinates

--- a/datatypes/src/raster/tiling.rs
+++ b/datatypes/src/raster/tiling.rs
@@ -1,12 +1,14 @@
-use crate::{
-    primitives::{AxisAlignedRectangle, Coordinate2D, SpatialPartition2D, SpatialPartitioned},
-    util::test::TestDefault,
-};
-
 use super::{
     GeoTransform, GridBoundingBox2D, GridIdx, GridIdx2D, GridShape2D, GridShapeAccess, GridSize,
 };
-
+use crate::{
+    primitives::{
+        AxisAlignedRectangle, Coordinate2D, RasterSpatialQueryRectangle, SpatialPartition2D,
+        SpatialPartitioned,
+    },
+    raster::GridBounds,
+    util::test::TestDefault,
+};
 use serde::{Deserialize, Serialize};
 
 /// The static parameters of a `TilingStrategy`
@@ -87,8 +89,10 @@ impl TilingStrategy {
     pub fn pixel_idx_to_tile_idx(&self, pixel_idx: GridIdx2D) -> GridIdx2D {
         let GridIdx([y_pixel_idx, x_pixel_idx]) = pixel_idx;
         let [y_tile_size, x_tile_size] = self.tile_size_in_pixels.into_inner();
-        let y_tile_idx = (y_pixel_idx as f64 / y_tile_size as f64).floor() as isize;
-        let x_tile_idx = (x_pixel_idx as f64 / x_tile_size as f64).floor() as isize;
+        //let y_tile_idx = (y_pixel_idx as f64 / y_tile_size as f64).floor() as isize;
+        //let x_tile_idx = (x_pixel_idx as f64 / x_tile_size as f64).floor() as isize;
+        let y_tile_idx = num::integer::div_floor(y_pixel_idx, y_tile_size as isize);
+        let x_tile_idx = num::integer::div_floor(x_pixel_idx, x_tile_size as isize);
         [y_tile_idx, x_tile_idx].into()
     }
 
@@ -98,33 +102,59 @@ impl TilingStrategy {
         GridBoundingBox2D::new_unchecked(start, end)
     }
 
-    /// generates the tile idx in \[z,y,x\] order for the tiles intersecting the bounding box
-    /// the iterator moves once along the x-axis and then increases the y-axis
-    pub fn tile_idx_iterator(
+    pub fn global_pixel_grid_bounds_to_tile_grid_bounds(
         &self,
-        partition: SpatialPartition2D,
+        global_pixel_grid_bounds: GridBoundingBox2D,
+    ) -> GridBoundingBox2D {
+        let start = self.pixel_idx_to_tile_idx(global_pixel_grid_bounds.min_index());
+        let end = self.pixel_idx_to_tile_idx(global_pixel_grid_bounds.max_index());
+        GridBoundingBox2D::new_unchecked(start, end)
+    }
+
+    /// Returns the tile grid bounds for the given `raster_spatial_query`.
+    /// The query must match the tiling strategy's geo transform for now.
+    ///
+    /// # Panics
+    /// If the query's geo transform does not match the tiling strategy's geo transform.
+    ///
+    pub fn raster_spatial_query_to_tiling_grid_box(
+        &self,
+        raster_spatial_query: &RasterSpatialQueryRectangle,
+    ) -> GridBoundingBox2D {
+        // FIXME: The query must match the tiling strategy's geo transform for now.
+        assert_eq!(
+            raster_spatial_query.geo_transform, self.geo_transform,
+            "The query geotransform must match the tiling strategy's geo transform for now."
+        );
+
+        self.global_pixel_grid_bounds_to_tile_grid_bounds(raster_spatial_query.grid_bounds)
+    }
+
+    /// Returns an iterator over all tile indices that intersect with the given `grid_bounds`.
+    pub fn tile_idx_iterator_from_grid_bounds(
+        &self,
+        grid_bounds: GridBoundingBox2D,
     ) -> impl Iterator<Item = GridIdx2D> {
         let GridIdx([upper_left_tile_y, upper_left_tile_x]) =
-            self.pixel_idx_to_tile_idx(self.geo_transform.upper_left_pixel_idx(&partition));
-
+            self.pixel_idx_to_tile_idx(grid_bounds.min_index());
         let GridIdx([lower_right_tile_y, lower_right_tile_x]) =
-            self.pixel_idx_to_tile_idx(self.geo_transform.lower_right_pixel_idx(&partition));
+            self.pixel_idx_to_tile_idx(grid_bounds.max_index());
 
         let y_range = upper_left_tile_y..=lower_right_tile_y;
         let x_range = upper_left_tile_x..=lower_right_tile_x;
 
-        y_range.flat_map(move |y_tile| x_range.clone().map(move |x_tile| [y_tile, x_tile].into()))
+        y_range.flat_map(move |y| x_range.clone().map(move |x| [y, x].into()))
     }
 
     /// generates the tile information for the tiles intersecting the bounding box
     /// the iterator moves once along the x-axis and then increases the y-axis
-    pub fn tile_information_iterator(
+    pub fn tile_information_iterator_from_grid_bounds(
         &self,
-        partition: SpatialPartition2D,
+        grid_bounds: GridBoundingBox2D,
     ) -> impl Iterator<Item = TileInformation> {
         let tile_pixel_size = self.tile_size_in_pixels;
         let geo_transform = self.geo_transform;
-        self.tile_idx_iterator(partition)
+        self.tile_idx_iterator_from_grid_bounds(grid_bounds)
             .map(move |idx| TileInformation::new(idx, tile_pixel_size, geo_transform))
     }
 }
@@ -202,6 +232,13 @@ impl TileInformation {
         self.global_upper_left_pixel_idx() + self.local_lower_left_pixel_idx()
     }
 
+    pub fn global_pixel_bounds(&self) -> GridBoundingBox2D {
+        GridBoundingBox2D::new_unchecked(
+            self.global_upper_left_pixel_idx(),
+            self.global_lower_right_pixel_idx(),
+        )
+    }
+
     pub fn tile_size_in_pixels(&self) -> GridShape2D {
         self.tile_size_in_pixels
     }
@@ -238,33 +275,43 @@ impl SpatialPartitioned for TileInformation {
 #[cfg(test)]
 mod tests {
 
+    use crate::raster::GridIntersection;
+
     use super::*;
 
     #[test]
     fn it_generates_only_intersected_tiles() {
+        let origin_coordinate = (0., 0.).into();
+
+        let geo_transform = GeoTransform::new(
+            origin_coordinate,
+            2.095_475_792_884_826_7E-8,
+            -2.095_475_792_884_826_7E-8,
+        );
+
         let strat = TilingStrategy {
             tile_size_in_pixels: [600, 600].into(),
-            geo_transform: GeoTransform::new(
-                (0., 0.).into(),
-                2.095_475_792_884_826_7E-8,
-                -2.095_475_792_884_826_7E-8,
-            ),
+            geo_transform,
         };
 
-        let partition = SpatialPartition2D::new(
-            (12.477_738_261_222_84, 43.881_293_535_232_544).into(),
-            (12.477_743_625_640_87, 43.881_288_170_814_514).into(),
-        )
-        .unwrap();
+        let ul_idx = strat
+            .geo_transform
+            .coordinate_to_grid_idx_2d((12.477_738_261_222_84, 43.881_293_535_232_544).into());
+
+        let lr_idx = strat
+            .geo_transform
+            .coordinate_to_grid_idx_2d((12.477_743_625_640_87, 43.881_288_170_814_514).into());
+
+        let grid_bounds = GridBoundingBox2D::new_unchecked(ul_idx, lr_idx);
 
         let tiles = strat
-            .tile_information_iterator(partition)
+            .tile_information_iterator_from_grid_bounds(grid_bounds)
             .collect::<Vec<_>>();
 
         assert_eq!(tiles.len(), 2);
 
         for tile in tiles {
-            assert!(partition.intersects(&tile.spatial_partition()));
+            assert!(grid_bounds.intersects(&tile.global_pixel_bounds()));
         }
     }
 }

--- a/operators/benches/cache.rs
+++ b/operators/benches/cache.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 use geoengine_datatypes::{
-    primitives::{QueryRectangle, SpatialPartition2D, SpatialResolution, TimeInterval},
+    primitives::{RasterQueryRectangle, SpatialPartition2D, SpatialResolution, TimeInterval},
     raster::TilesEqualIgnoringCacheHint,
     util::test::TestDefault,
 };
@@ -66,14 +66,12 @@ async fn main() {
 
     let stream = processor
         .query(
-            QueryRectangle {
-                spatial_bounds: SpatialPartition2D::new_unchecked(
-                    [-180., -90.].into(),
-                    [180., 90.].into(),
-                ),
-                time_interval: TimeInterval::default(),
-                spatial_resolution: SpatialResolution::zero_point_one(),
-            },
+            RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                SpatialPartition2D::new_unchecked([-180., -90.].into(), [180., 90.].into()),
+                SpatialResolution::zero_point_one(),
+                exe_ctx.tiling_specification.origin_coordinate,
+                TimeInterval::default(),
+            ),
             &query_ctx,
         )
         .await
@@ -89,14 +87,12 @@ async fn main() {
 
     let stream_from_cache = processor
         .query(
-            QueryRectangle {
-                spatial_bounds: SpatialPartition2D::new_unchecked(
-                    [-180., -90.].into(),
-                    [180., 90.].into(),
-                ),
-                time_interval: TimeInterval::default(),
-                spatial_resolution: SpatialResolution::zero_point_one(),
-            },
+            RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                SpatialPartition2D::new_unchecked([-180., -90.].into(), [180., 90.].into()),
+                SpatialResolution::zero_point_one(),
+                exe_ctx.tiling_specification.origin_coordinate,
+                TimeInterval::default(),
+            ),
             &query_ctx,
         )
         .await

--- a/operators/benches/cache_concurrent.rs
+++ b/operators/benches/cache_concurrent.rs
@@ -109,11 +109,12 @@ async fn read_cache(tile_cache: &SharedCache, op_no: usize) -> ReadMeasurement {
 }
 
 fn query_rect() -> RasterQueryRectangle {
-    RasterQueryRectangle {
-        spatial_bounds: SpatialPartition2D::new_unchecked((-180., 90.).into(), (180., -90.).into()),
-        time_interval: TimeInterval::new_instant(DateTime::new_utc(2014, 3, 1, 0, 0, 0)).unwrap(),
-        spatial_resolution: SpatialResolution::one(),
-    }
+    RasterQueryRectangle::with_partition_and_resolution_and_origin(
+        SpatialPartition2D::new_unchecked((-180., 90.).into(), (180., -90.).into()),
+        SpatialResolution::one(),
+        [0., 0.].into(), // TODO: replace with default or remove
+        TimeInterval::new_instant(DateTime::new_utc(2014, 3, 1, 0, 0, 0)).unwrap(),
+    )
 }
 
 fn op(idx: usize) -> CanonicOperatorName {

--- a/operators/benches/expression.rs
+++ b/operators/benches/expression.rs
@@ -67,11 +67,12 @@ async fn main() {
         .unwrap();
 
     // World in 36000x18000 pixels",
-    let qrect = RasterQueryRectangle {
-        spatial_bounds: SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into()).unwrap(),
-        time_interval: TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
-        spatial_resolution: SpatialResolution::new(0.01, 0.01).unwrap(),
-    };
+    let qrect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+        SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into()).unwrap(),
+        SpatialResolution::new(0.01, 0.01).unwrap(),
+        execution_context.tiling_specification.origin_coordinate,
+        TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
+    );
 
     let mut times = NumberStatistics::default();
 

--- a/operators/benches/pip.rs
+++ b/operators/benches/pip.rs
@@ -3,7 +3,7 @@ use geo_rand::{GeoRand, GeoRandParameters};
 use geoengine_datatypes::collections::{FeatureCollectionInfos, MultiPolygonCollection};
 use geoengine_datatypes::primitives::CacheHint;
 use geoengine_datatypes::primitives::{
-    BoundingBox2D, MultiPoint, QueryRectangle, SpatialResolution,
+    BoundingBox2D, MultiPoint, SpatialResolution, VectorQueryRectangle,
 };
 use geoengine_datatypes::util::test::TestDefault;
 use geoengine_datatypes::{collections::MultiPointCollection, primitives::TimeInterval};
@@ -42,11 +42,11 @@ async fn pip(points: MultiPointCollection, polygons: MultiPolygonCollection, num
 
     let query_processor = operator.query_processor().unwrap().multi_point().unwrap();
 
-    let query_rectangle = QueryRectangle {
-        spatial_bounds: BoundingBox2D::new((0., 0.).into(), (10., 10.).into()).unwrap(),
-        time_interval: TimeInterval::default(),
-        spatial_resolution: SpatialResolution::zero_point_one(),
-    };
+    let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+        BoundingBox2D::new((0., 0.).into(), (10., 10.).into()).unwrap(),
+        TimeInterval::default(),
+        SpatialResolution::zero_point_one(),
+    );
     let ctx = MockQueryContext::with_chunk_size_and_thread_count(ChunkByteSize::MAX, num_threads);
 
     let query = query_processor.query(query_rectangle, &ctx).await.unwrap();

--- a/operators/benches/query_chunks.rs
+++ b/operators/benches/query_chunks.rs
@@ -19,8 +19,8 @@ use csv::WriterBuilder;
 use futures::StreamExt;
 use geoengine_datatypes::{
     primitives::{
-        BoundingBox2D, QueryRectangle, RasterQueryRectangle, SpatialPartition2D, SpatialResolution,
-        TimeInterval, VectorQueryRectangle,
+        BoundingBox2D, RasterQueryRectangle, SpatialPartition2D, SpatialResolution, TimeInterval,
+        VectorQueryRectangle,
     },
     raster::Pixel,
     util::{test::TestDefault, Identifier},
@@ -104,14 +104,12 @@ fn setup_benchmarks(exe_ctx: &mut StatisticsWrappingMockExecutionContext) -> Vec
                 },
             }
             .boxed(),
-            query_rectangle: QueryRectangle {
-                spatial_bounds: SpatialPartition2D::new_unchecked(
-                    [-180., -90.].into(),
-                    [180., 90.].into(),
-                ),
-                time_interval: TimeInterval::default(),
-                spatial_resolution: SpatialResolution::zero_point_one(),
-            },
+            query_rectangle: RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                SpatialPartition2D::new_unchecked([-180., -90.].into(), [180., 90.].into()),
+                SpatialResolution::zero_point_one(),
+                (0., 0.).into(),
+                TimeInterval::default(),
+            ),
         },
         Benchmark::Vector {
             name: "raster_vector_join".to_string(),
@@ -139,14 +137,11 @@ fn setup_benchmarks(exe_ctx: &mut StatisticsWrappingMockExecutionContext) -> Vec
                 },
             }
             .boxed(),
-            query_rectangle: QueryRectangle {
-                spatial_bounds: BoundingBox2D::new_unchecked(
-                    [-180., -90.].into(),
-                    [180., 90.].into(),
-                ),
-                time_interval: TimeInterval::default(),
-                spatial_resolution: SpatialResolution::zero_point_one(),
-            },
+            query_rectangle: VectorQueryRectangle::with_bounds_and_resolution(
+                BoundingBox2D::new_unchecked([-180., -90.].into(), [180., 90.].into()),
+                TimeInterval::default(),
+                SpatialResolution::zero_point_one(),
+            ),
         },
     ]
 }

--- a/operators/benches/sources.rs
+++ b/operators/benches/sources.rs
@@ -1,8 +1,6 @@
-use std::time::Instant;
-use std::{hint::black_box, marker::PhantomData};
-
 use futures::StreamExt;
 use geoengine_datatypes::primitives::CacheHint;
+use geoengine_datatypes::primitives::Coordinate2D;
 use geoengine_datatypes::{
     primitives::{RasterQueryRectangle, SpatialPartition2D, SpatialResolution, TimeInterval},
     raster::{
@@ -16,6 +14,8 @@ use geoengine_operators::{
     source::{GdalMetaDataRegular, GdalSourceProcessor},
     util::gdal::create_ndvi_meta_data,
 };
+use std::time::Instant;
+use std::{hint::black_box, marker::PhantomData};
 
 fn setup_gdal_source(
     meta_data: GdalMetaDataRegular,
@@ -160,60 +160,58 @@ fn bench_raster_processor<
 }
 
 fn bench_no_data_tiles() {
+    let tiling_origin = Coordinate2D::new(0., 0.);
+    let spatial_resolution = SpatialResolution::zero_point_one();
+
     let qrects = vec![
         (
             "1 tile",
-            RasterQueryRectangle {
-                spatial_bounds: SpatialPartition2D::new((0., 60.).into(), (60., 0.).into())
-                    .unwrap(),
-                time_interval: TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000)
-                    .unwrap(),
-                spatial_resolution: SpatialResolution::zero_point_one(),
-            },
+            RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                SpatialPartition2D::new((0., 60.).into(), (60., 0.).into()).unwrap(),
+                spatial_resolution,
+                tiling_origin,
+                TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
+            ),
         ),
         (
             "2 tiles",
-            RasterQueryRectangle {
-                spatial_bounds: SpatialPartition2D::new((0., 50.).into(), (60., -10.).into())
-                    .unwrap(),
-                time_interval: TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000)
-                    .unwrap(),
-                spatial_resolution: SpatialResolution::zero_point_one(),
-            },
+            RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                SpatialPartition2D::new((0., 50.).into(), (60., -10.).into()).unwrap(),
+                spatial_resolution,
+                tiling_origin,
+                TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
+            ),
         ),
         (
             "4 tiles",
-            RasterQueryRectangle {
-                spatial_bounds: SpatialPartition2D::new((-5., 50.).into(), (55., -10.).into())
-                    .unwrap(),
-                time_interval: TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000)
-                    .unwrap(),
-                spatial_resolution: SpatialResolution::zero_point_one(),
-            },
+            RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                SpatialPartition2D::new((-5., 50.).into(), (55., -10.).into()).unwrap(),
+                spatial_resolution,
+                tiling_origin,
+                TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
+            ),
         ),
         (
             "2 tiles, 2 no-data tiles",
-            RasterQueryRectangle {
-                spatial_bounds: SpatialPartition2D::new((130., 120.).into(), (190., 60.).into())
-                    .unwrap(),
-                time_interval: TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000)
-                    .unwrap(),
-                spatial_resolution: SpatialResolution::zero_point_one(),
-            },
+            RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                SpatialPartition2D::new((130., 120.).into(), (190., 60.).into()).unwrap(),
+                spatial_resolution,
+                tiling_origin,
+                TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
+            ),
         ),
         (
             "empty tiles",
-            RasterQueryRectangle {
-                spatial_bounds: SpatialPartition2D::new((-5., 50.).into(), (55., -10.).into())
-                    .unwrap(),
-                time_interval: TimeInterval::new(1_000_000_000_000, 1_000_000_000_000 + 1000)
-                    .unwrap(),
-                spatial_resolution: SpatialResolution::zero_point_one(),
-            },
+            RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                SpatialPartition2D::new((-5., 50.).into(), (55., -10.).into()).unwrap(),
+                spatial_resolution,
+                tiling_origin,
+                TimeInterval::new(1_000_000_000_000, 1_000_000_000_000 + 1000).unwrap(),
+            ),
         ),
     ];
 
-    let tiling_specs = vec![TilingSpecification::new((0., 0.).into(), [600, 600].into())];
+    let tiling_specs = vec![TilingSpecification::new(tiling_origin, [600, 600].into())];
 
     let run_time = tokio::runtime::Runtime::new().unwrap();
     let ctx = MockQueryContext::with_chunk_size_and_thread_count(ChunkByteSize::MAX, 8);
@@ -237,31 +235,33 @@ fn bench_no_data_tiles() {
 }
 
 fn bench_tile_size() {
+    let tiling_origin = Coordinate2D::new(0., 0.);
+
     let qrects = vec![(
         "World in 36000x18000 pixels",
-        RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into())
-                .unwrap(),
-            time_interval: TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
-            spatial_resolution: SpatialResolution::new(0.01, 0.01).unwrap(),
-        },
+        RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into()).unwrap(),
+            SpatialResolution::new(0.01, 0.01).unwrap(),
+            tiling_origin,
+            TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
+        ),
     )];
 
     let run_time = tokio::runtime::Runtime::new().unwrap();
     let ctx = MockQueryContext::with_chunk_size_and_thread_count(ChunkByteSize::MAX, 8);
 
     let tiling_specs = vec![
-        TilingSpecification::new((0., 0.).into(), [32, 32].into()),
-        TilingSpecification::new((0., 0.).into(), [64, 64].into()),
-        TilingSpecification::new((0., 0.).into(), [128, 128].into()),
-        TilingSpecification::new((0., 0.).into(), [256, 256].into()),
-        TilingSpecification::new((0., 0.).into(), [512, 512].into()),
-        TilingSpecification::new((0., 0.).into(), [600, 600].into()),
-        TilingSpecification::new((0., 0.).into(), [900, 900].into()),
-        TilingSpecification::new((0., 0.).into(), [1024, 1024].into()),
-        TilingSpecification::new((0., 0.).into(), [2048, 2048].into()),
-        TilingSpecification::new((0., 0.).into(), [4096, 4096].into()),
-        TilingSpecification::new((0., 0.).into(), [9000, 9000].into()),
+        TilingSpecification::new(tiling_origin, [32, 32].into()),
+        TilingSpecification::new(tiling_origin, [64, 64].into()),
+        TilingSpecification::new(tiling_origin, [128, 128].into()),
+        TilingSpecification::new(tiling_origin, [256, 256].into()),
+        TilingSpecification::new(tiling_origin, [512, 512].into()),
+        TilingSpecification::new(tiling_origin, [600, 600].into()),
+        TilingSpecification::new(tiling_origin, [900, 900].into()),
+        TilingSpecification::new(tiling_origin, [1024, 1024].into()),
+        TilingSpecification::new(tiling_origin, [2048, 2048].into()),
+        TilingSpecification::new(tiling_origin, [4096, 4096].into()),
+        TilingSpecification::new(tiling_origin, [9000, 9000].into()),
     ];
 
     bench_raster_processor(

--- a/operators/benches/workflows.rs
+++ b/operators/benches/workflows.rs
@@ -4,10 +4,8 @@ use std::time::{Duration, Instant};
 use futures::TryStreamExt;
 use geoengine_datatypes::dataset::{DataId, DatasetId, NamedData};
 use geoengine_datatypes::primitives::CacheHint;
-use geoengine_datatypes::primitives::{
-    Measurement, QueryRectangle, RasterQueryRectangle, SpatialPartitioned,
-};
-use geoengine_datatypes::raster::{Grid2D, RasterDataType};
+use geoengine_datatypes::primitives::{Coordinate2D, Measurement, RasterQueryRectangle};
+use geoengine_datatypes::raster::{Grid2D, RasterDataType, TilingStrategy};
 use geoengine_datatypes::spatial_reference::SpatialReference;
 
 use geoengine_datatypes::util::Identifier;
@@ -58,7 +56,7 @@ pub trait BenchmarkRunner {
 pub struct WorkflowSingleBenchmark<F, O> {
     bench_id: &'static str,
     query_name: &'static str,
-    query_rect: QueryRectangle<SpatialPartition2D>,
+    query_rect: RasterQueryRectangle,
     tiling_spec: TilingSpecification,
     chunk_byte_size: ChunkByteSize,
     num_threads: usize,
@@ -69,7 +67,7 @@ pub struct WorkflowSingleBenchmark<F, O> {
 impl<O, F> WorkflowSingleBenchmark<F, O>
 where
     F: Fn(TilingSpecification, usize) -> MockExecutionContext,
-    O: Fn(TilingSpecification, QueryRectangle<SpatialPartition2D>) -> Box<dyn RasterOperator>,
+    O: Fn(TilingSpecification, RasterQueryRectangle) -> Box<dyn RasterOperator>,
 {
     #[inline(never)]
     pub fn run_bench(&self) -> WorkflowBenchmarkResult {
@@ -129,7 +127,7 @@ where
 impl<F, O> BenchmarkRunner for WorkflowSingleBenchmark<F, O>
 where
     F: Fn(TilingSpecification, usize) -> MockExecutionContext,
-    O: Fn(TilingSpecification, QueryRectangle<SpatialPartition2D>) -> Box<dyn RasterOperator>,
+    O: Fn(TilingSpecification, RasterQueryRectangle) -> Box<dyn RasterOperator>,
 {
     fn run_all_benchmarks(self, bencher: &mut BenchmarkCollector) {
         bencher.add_benchmark_result(WorkflowSingleBenchmark::run_bench(&self))
@@ -153,8 +151,7 @@ where
     T: IntoIterator<Item = TilingSpecification> + Clone,
     B: IntoIterator<Item = ChunkByteSize> + Clone,
     F: Clone + Fn(TilingSpecification, usize) -> MockExecutionContext,
-    O: Clone
-        + Fn(TilingSpecification, QueryRectangle<SpatialPartition2D>) -> Box<dyn RasterOperator>,
+    O: Clone + Fn(TilingSpecification, RasterQueryRectangle) -> Box<dyn RasterOperator>,
 {
     pub fn new(
         bench_id: &'static str,
@@ -234,8 +231,7 @@ where
     T: IntoIterator<Item = TilingSpecification> + Clone,
     B: IntoIterator<Item = ChunkByteSize> + Clone,
     F: Clone + Fn(TilingSpecification, usize) -> MockExecutionContext,
-    O: Clone
-        + Fn(TilingSpecification, QueryRectangle<SpatialPartition2D>) -> Box<dyn RasterOperator>,
+    O: Clone + Fn(TilingSpecification, RasterQueryRectangle) -> Box<dyn RasterOperator>,
 {
     fn run_all_benchmarks(self, bencher: &mut BenchmarkCollector) {
         self.into_benchmark_iterator()
@@ -271,12 +267,15 @@ where
 }
 
 fn bench_mock_source_operator(bench_collector: &mut BenchmarkCollector) {
-    let qrect = RasterQueryRectangle {
-        spatial_bounds: SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into()).unwrap(),
-        time_interval: TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
-        spatial_resolution: SpatialResolution::new(0.01, 0.01).unwrap(),
-    };
-    let tiling_spec = TilingSpecification::new((0., 0.).into(), [512, 512].into());
+    let tiling_origin = Coordinate2D::new(0., 0.);
+
+    let qrect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+        SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into()).unwrap(),
+        SpatialResolution::new(0.01, 0.01).unwrap(),
+        tiling_origin,
+        TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
+    );
+    let tiling_spec = TilingSpecification::new(tiling_origin, [512, 512].into());
 
     let qrects = vec![("World in 36000x18000 pixels", qrect)];
     let tiling_specs = vec![tiling_spec];
@@ -285,10 +284,19 @@ fn bench_mock_source_operator(bench_collector: &mut BenchmarkCollector) {
         tiling_spec: TilingSpecification,
         query_rect: RasterQueryRectangle,
     ) -> Box<dyn RasterOperator> {
-        let query_resolution = query_rect.spatial_resolution;
-        let query_time = query_rect.time_interval;
-        let tileing_strategy = tiling_spec.strategy(query_resolution.x, -1. * query_resolution.y);
-        let tile_iter = tileing_strategy.tile_information_iterator(query_rect.spatial_partition());
+        // FIXME: The query origin must match the tiling strategy's origin for now. Also use grid bounds not spatial bounds.
+        assert_eq!(
+            query_rect.spatial_query().geo_transform.origin_coordinate(),
+            tiling_spec.origin_coordinate,
+            "The query origin coordinate must match the tiling strategy's origin for now."
+        );
+
+        let tileing_strategy = TilingStrategy::new(
+            tiling_spec.tile_size_in_pixels,
+            query_rect.spatial_query().geo_transform,
+        );
+        let tile_iter = tileing_strategy
+            .tile_information_iterator_from_grid_bounds(query_rect.spatial_query().grid_bounds);
 
         let mock_data = tile_iter
             .enumerate()
@@ -299,7 +307,7 @@ fn bench_mock_source_operator(bench_collector: &mut BenchmarkCollector) {
                 )
                 .unwrap();
                 RasterTile2D::new_with_tile_info(
-                    query_time,
+                    query_rect.time_interval,
                     tile_info,
                     data.into(),
                     CacheHint::default(),
@@ -338,30 +346,42 @@ fn bench_mock_source_operator(bench_collector: &mut BenchmarkCollector) {
 }
 
 fn bench_mock_source_operator_with_expression(bench_collector: &mut BenchmarkCollector) {
-    let qrect = RasterQueryRectangle {
-        spatial_bounds: SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into()).unwrap(),
-        time_interval: TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
-        spatial_resolution: SpatialResolution::new(0.005, 0.005).unwrap(),
-    };
+    let tiling_origin = Coordinate2D::new(0., 0.);
+
+    let qrect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+        SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into()).unwrap(),
+        SpatialResolution::new(0.005, 0.005).unwrap(),
+        tiling_origin,
+        TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
+    );
 
     let qrects = vec![("World in 72000x36000 pixels", qrect)];
     let tiling_specs = vec![
-        TilingSpecification::new((0., 0.).into(), [512, 512].into()),
-        TilingSpecification::new((0., 0.).into(), [1024, 1024].into()),
-        TilingSpecification::new((0., 0.).into(), [2048, 2048].into()),
-        TilingSpecification::new((0., 0.).into(), [4096, 4096].into()),
-        TilingSpecification::new((0., 0.).into(), [9000, 9000].into()),
-        TilingSpecification::new((0., 0.).into(), [18000, 18000].into()),
+        TilingSpecification::new(tiling_origin, [512, 512].into()),
+        TilingSpecification::new(tiling_origin, [1024, 1024].into()),
+        TilingSpecification::new(tiling_origin, [2048, 2048].into()),
+        TilingSpecification::new(tiling_origin, [4096, 4096].into()),
+        TilingSpecification::new(tiling_origin, [9000, 9000].into()),
+        TilingSpecification::new(tiling_origin, [18000, 18000].into()),
     ];
 
     fn operator_builder(
         tiling_spec: TilingSpecification,
         query_rect: RasterQueryRectangle,
     ) -> Box<dyn RasterOperator> {
-        let query_resolution = query_rect.spatial_resolution;
-        let query_time = query_rect.time_interval;
-        let tileing_strategy = tiling_spec.strategy(query_resolution.x, -1. * query_resolution.y);
-        let tile_iter = tileing_strategy.tile_information_iterator(query_rect.spatial_partition());
+        // FIXME: The query origin must match the tiling strategy's origin for now. Also use grid bounds not spatial bounds.
+        assert_eq!(
+            query_rect.spatial_query().geo_transform.origin_coordinate(),
+            tiling_spec.origin_coordinate,
+            "The query origin coordinate must match the tiling strategy's origin for now."
+        );
+
+        let tileing_strategy = TilingStrategy::new(
+            tiling_spec.tile_size_in_pixels,
+            query_rect.spatial_query().geo_transform,
+        );
+        let tile_iter = tileing_strategy
+            .tile_information_iterator_from_grid_bounds(query_rect.spatial_query().grid_bounds);
 
         let mock_data = tile_iter
             .enumerate()
@@ -372,7 +392,7 @@ fn bench_mock_source_operator_with_expression(bench_collector: &mut BenchmarkCol
                 )
                 .unwrap();
                 RasterTile2D::new_with_tile_info(
-                    query_time,
+                    query_rect.time_interval,
                     tile_info,
                     data.into(),
                     CacheHint::default(),
@@ -424,30 +444,42 @@ fn bench_mock_source_operator_with_expression(bench_collector: &mut BenchmarkCol
 }
 
 fn bench_mock_source_operator_with_identity_reprojection(bench_collector: &mut BenchmarkCollector) {
-    let qrect = RasterQueryRectangle {
-        spatial_bounds: SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into()).unwrap(),
-        time_interval: TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
-        spatial_resolution: SpatialResolution::new(0.01, 0.01).unwrap(),
-    };
+    let tiling_origin = Coordinate2D::new(0., 0.);
+
+    let qrect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+        SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into()).unwrap(),
+        SpatialResolution::new(0.01, 0.01).unwrap(),
+        tiling_origin,
+        TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
+    );
 
     let qrects = vec![("World in 36000x18000 pixels", qrect)];
     let tiling_specs = vec![
-        TilingSpecification::new((0., 0.).into(), [512, 512].into()),
-        TilingSpecification::new((0., 0.).into(), [1024, 1024].into()),
-        TilingSpecification::new((0., 0.).into(), [2048, 2048].into()),
-        TilingSpecification::new((0., 0.).into(), [4096, 4096].into()),
-        TilingSpecification::new((0., 0.).into(), [9000, 9000].into()),
-        TilingSpecification::new((0., 0.).into(), [18000, 18000].into()),
+        TilingSpecification::new(tiling_origin, [512, 512].into()),
+        TilingSpecification::new(tiling_origin, [1024, 1024].into()),
+        TilingSpecification::new(tiling_origin, [2048, 2048].into()),
+        TilingSpecification::new(tiling_origin, [4096, 4096].into()),
+        TilingSpecification::new(tiling_origin, [9000, 9000].into()),
+        TilingSpecification::new(tiling_origin, [18000, 18000].into()),
     ];
 
     fn operator_builder(
         tiling_spec: TilingSpecification,
         query_rect: RasterQueryRectangle,
     ) -> Box<dyn RasterOperator> {
-        let query_resolution = query_rect.spatial_resolution;
-        let query_time = query_rect.time_interval;
-        let tileing_strategy = tiling_spec.strategy(query_resolution.x, -1. * query_resolution.y);
-        let tile_iter = tileing_strategy.tile_information_iterator(query_rect.spatial_partition());
+        // FIXME: The query origin must match the tiling strategy's origin for now. Also use grid bounds not spatial bounds.
+        assert_eq!(
+            query_rect.spatial_query().geo_transform.origin_coordinate(),
+            tiling_spec.origin_coordinate,
+            "The query origin coordinate must match the tiling strategy's origin for now."
+        );
+
+        let tileing_strategy = TilingStrategy::new(
+            tiling_spec.tile_size_in_pixels,
+            query_rect.spatial_query().geo_transform,
+        );
+        let tile_iter = tileing_strategy
+            .tile_information_iterator_from_grid_bounds(query_rect.spatial_query().grid_bounds);
         let mock_data = tile_iter
             .enumerate()
             .map(|(id, tile_info)| {
@@ -457,7 +489,7 @@ fn bench_mock_source_operator_with_identity_reprojection(bench_collector: &mut B
                 )
                 .unwrap();
                 RasterTile2D::new_with_tile_info(
-                    query_time,
+                    query_rect.time_interval,
                     tile_info,
                     data.into(),
                     CacheHint::default(),
@@ -505,15 +537,18 @@ fn bench_mock_source_operator_with_identity_reprojection(bench_collector: &mut B
 fn bench_mock_source_operator_with_4326_to_3857_reprojection(
     bench_collector: &mut BenchmarkCollector,
 ) {
-    let qrect = RasterQueryRectangle {
-        spatial_bounds: SpatialPartition2D::new(
+    let tiling_origin = Coordinate2D::new(0., 0.);
+
+    let qrect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+        SpatialPartition2D::new(
             (-20_037_508.342_789_244, 20_048_966.104_014_594).into(),
             (20_037_508.342_789_244, -20_048_966.104_014_594).into(),
         )
         .unwrap(),
-        time_interval: TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
-        spatial_resolution: SpatialResolution::new(1050., 2100.).unwrap(),
-    };
+        SpatialResolution::new(1050., 2100.).unwrap(),
+        tiling_origin,
+        TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
+    );
     let tiling_spec = TilingSpecification::new((0., 0.).into(), [512, 512].into());
 
     let qrects = vec![("World in 36000x18000 pixels", qrect)];
@@ -523,10 +558,20 @@ fn bench_mock_source_operator_with_4326_to_3857_reprojection(
         tiling_spec: TilingSpecification,
         query_rect: RasterQueryRectangle,
     ) -> Box<dyn RasterOperator> {
-        let query_resolution = query_rect.spatial_resolution;
-        let query_time = query_rect.time_interval;
-        let tileing_strategy = tiling_spec.strategy(query_resolution.x, -1. * query_resolution.y);
-        let tile_iter = tileing_strategy.tile_information_iterator(query_rect.spatial_partition());
+        // FIXME: The query origin must match the tiling strategy's origin for now. Also use grid bounds not spatial bounds.
+        assert_eq!(
+            query_rect.spatial_query().geo_transform.origin_coordinate(),
+            tiling_spec.origin_coordinate,
+            "The query origin coordinate must match the tiling strategy's origin for now."
+        );
+
+        let tileing_strategy = TilingStrategy::new(
+            tiling_spec.tile_size_in_pixels,
+            query_rect.spatial_query().geo_transform,
+        );
+
+        let tile_iter = tileing_strategy
+            .tile_information_iterator_from_grid_bounds(query_rect.spatial_query().grid_bounds);
         let mock_data = tile_iter
             .enumerate()
             .map(|(id, tile_info)| {
@@ -536,7 +581,7 @@ fn bench_mock_source_operator_with_4326_to_3857_reprojection(
                 )
                 .unwrap();
                 RasterTile2D::new_with_tile_info(
-                    query_time,
+                    query_rect.time_interval,
                     tile_info,
                     data.into(),
                     CacheHint::default(),
@@ -581,40 +626,40 @@ fn bench_mock_source_operator_with_4326_to_3857_reprojection(
 }
 
 fn bench_gdal_source_operator_tile_size(bench_collector: &mut BenchmarkCollector) {
+    let tiling_origin = Coordinate2D::new(0., 0.);
+
     let qrects = vec![
         (
             "World in 36000x18000 pixels",
-            RasterQueryRectangle {
-                spatial_bounds: SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into())
-                    .unwrap(),
-                time_interval: TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000)
-                    .unwrap(),
-                spatial_resolution: SpatialResolution::new(0.01, 0.01).unwrap(),
-            },
+            RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into()).unwrap(),
+                SpatialResolution::new(0.01, 0.01).unwrap(),
+                tiling_origin,
+                TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
+            ),
         ),
         (
             "World in 72000x36000 pixels",
-            RasterQueryRectangle {
-                spatial_bounds: SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into())
-                    .unwrap(),
-                time_interval: TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000)
-                    .unwrap(),
-                spatial_resolution: SpatialResolution::new(0.005, 0.005).unwrap(),
-            },
+            RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into()).unwrap(),
+                SpatialResolution::new(0.005, 0.005).unwrap(),
+                tiling_origin,
+                TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
+            ),
         ),
     ];
 
     let tiling_specs = vec![
-        TilingSpecification::new((0., 0.).into(), [32, 32].into()),
-        TilingSpecification::new((0., 0.).into(), [64, 64].into()),
-        TilingSpecification::new((0., 0.).into(), [128, 128].into()),
-        TilingSpecification::new((0., 0.).into(), [256, 256].into()),
-        TilingSpecification::new((0., 0.).into(), [512, 512].into()),
+        TilingSpecification::new(tiling_origin, [32, 32].into()),
+        TilingSpecification::new(tiling_origin, [64, 64].into()),
+        TilingSpecification::new(tiling_origin, [128, 128].into()),
+        TilingSpecification::new(tiling_origin, [256, 256].into()),
+        TilingSpecification::new(tiling_origin, [512, 512].into()),
         // TilingSpecification::new((0., 0.).into(), [600, 600].into()),
         // TilingSpecification::new((0., 0.).into(), [900, 900].into()),
-        TilingSpecification::new((0., 0.).into(), [1024, 1024].into()),
-        TilingSpecification::new((0., 0.).into(), [2048, 2048].into()),
-        TilingSpecification::new((0., 0.).into(), [4096, 4096].into()),
+        TilingSpecification::new(tiling_origin, [1024, 1024].into()),
+        TilingSpecification::new(tiling_origin, [2048, 2048].into()),
+        TilingSpecification::new(tiling_origin, [4096, 4096].into()),
         // TilingSpecification::new((0., 0.).into(), [9000, 9000].into()),
     ];
 
@@ -645,27 +690,29 @@ fn bench_gdal_source_operator_tile_size(bench_collector: &mut BenchmarkCollector
 }
 
 fn bench_gdal_source_operator_with_expression_tile_size(bench_collector: &mut BenchmarkCollector) {
+    let tiling_origin = Coordinate2D::new(0., 0.);
+
     let qrects = vec![(
         "World in 36000x18000 pixels",
-        RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into())
-                .unwrap(),
-            time_interval: TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
-            spatial_resolution: SpatialResolution::new(0.01, 0.01).unwrap(),
-        },
+        RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into()).unwrap(),
+            SpatialResolution::new(0.01, 0.01).unwrap(),
+            tiling_origin,
+            TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
+        ),
     )];
 
     let tiling_specs = vec![
         // TilingSpecification::new((0., 0.).into(), [32, 32].into()),
-        TilingSpecification::new((0., 0.).into(), [64, 64].into()),
-        TilingSpecification::new((0., 0.).into(), [128, 128].into()),
-        TilingSpecification::new((0., 0.).into(), [256, 256].into()),
-        TilingSpecification::new((0., 0.).into(), [512, 512].into()),
+        TilingSpecification::new(tiling_origin, [64, 64].into()),
+        TilingSpecification::new(tiling_origin, [128, 128].into()),
+        TilingSpecification::new(tiling_origin, [256, 256].into()),
+        TilingSpecification::new(tiling_origin, [512, 512].into()),
         // TilingSpecification::new((0., 0.).into(), [600, 600].into()),
         // TilingSpecification::new((0., 0.).into(), [900, 900].into()),
-        TilingSpecification::new((0., 0.).into(), [1024, 1024].into()),
-        TilingSpecification::new((0., 0.).into(), [2048, 2048].into()),
-        TilingSpecification::new((0., 0.).into(), [4096, 4096].into()),
+        TilingSpecification::new(tiling_origin, [1024, 1024].into()),
+        TilingSpecification::new(tiling_origin, [2048, 2048].into()),
+        TilingSpecification::new(tiling_origin, [4096, 4096].into()),
         // TilingSpecification::new((0., 0.).into(), [9000, 9000].into()),
     ];
 
@@ -706,27 +753,29 @@ fn bench_gdal_source_operator_with_expression_tile_size(bench_collector: &mut Be
 }
 
 fn bench_gdal_source_operator_with_identity_reprojection(bench_collector: &mut BenchmarkCollector) {
+    let tiling_origin = Coordinate2D::new(0., 0.);
+
     let qrects = vec![(
         "World in 36000x18000 pixels",
-        RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into())
-                .unwrap(),
-            time_interval: TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
-            spatial_resolution: SpatialResolution::new(0.01, 0.01).unwrap(),
-        },
+        RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into()).unwrap(),
+            SpatialResolution::new(0.01, 0.01).unwrap(),
+            tiling_origin,
+            TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
+        ),
     )];
 
     let tiling_specs = vec![
         // TilingSpecification::new((0., 0.).into(), [32, 32].into()),
         // TilingSpecification::new((0., 0.).into(), [64, 64].into()),
         // TilingSpecification::new((0., 0.).into(), [128, 128].into()),
-        TilingSpecification::new((0., 0.).into(), [256, 256].into()),
-        TilingSpecification::new((0., 0.).into(), [512, 512].into()),
+        TilingSpecification::new(tiling_origin, [256, 256].into()),
+        TilingSpecification::new(tiling_origin, [512, 512].into()),
         // TilingSpecification::new((0., 0.).into(), [600, 600].into()),
         // TilingSpecification::new((0., 0.).into(), [900, 900].into()),
-        TilingSpecification::new((0., 0.).into(), [1024, 1024].into()),
-        TilingSpecification::new((0., 0.).into(), [2048, 2048].into()),
-        TilingSpecification::new((0., 0.).into(), [4096, 4096].into()),
+        TilingSpecification::new(tiling_origin, [1024, 1024].into()),
+        TilingSpecification::new(tiling_origin, [2048, 2048].into()),
+        TilingSpecification::new(tiling_origin, [4096, 4096].into()),
         // TilingSpecification::new((0., 0.).into(), [9000, 9000].into()),
     ];
 
@@ -766,17 +815,20 @@ fn bench_gdal_source_operator_with_identity_reprojection(bench_collector: &mut B
 fn bench_gdal_source_operator_with_4326_to_3857_reprojection(
     bench_collector: &mut BenchmarkCollector,
 ) {
+    let tiling_origin = Coordinate2D::new(0., 0.);
+
     let qrects = vec![(
         "World in EPSG:3857 ~ 40000 x 20000 px",
-        RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new(
+        RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new(
                 (-20_037_508.342_789_244, 20_048_966.104_014_594).into(),
                 (20_037_508.342_789_244, -20_048_966.104_014_594).into(),
             )
             .unwrap(),
-            time_interval: TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
-            spatial_resolution: SpatialResolution::new(1050., 2100.).unwrap(),
-        },
+            SpatialResolution::new(1050., 2100.).unwrap(),
+            tiling_origin,
+            TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
+        ),
     )];
 
     let tiling_specs = vec![
@@ -784,12 +836,12 @@ fn bench_gdal_source_operator_with_4326_to_3857_reprojection(
         // TilingSpecification::new((0., 0.).into(), [64, 64].into()),
         // TilingSpecification::new((0., 0.).into(), [128, 128].into()),
         // TilingSpecification::new((0., 0.).into(), [256, 256].into()),
-        TilingSpecification::new((0., 0.).into(), [512, 512].into()),
+        TilingSpecification::new(tiling_origin, [512, 512].into()),
         // TilingSpecification::new((0., 0.).into(), [600, 600].into()),
         // TilingSpecification::new((0., 0.).into(), [900, 900].into()),
-        TilingSpecification::new((0., 0.).into(), [1024, 1024].into()),
-        TilingSpecification::new((0., 0.).into(), [2048, 2048].into()),
-        TilingSpecification::new((0., 0.).into(), [4096, 4096].into()),
+        TilingSpecification::new(tiling_origin, [1024, 1024].into()),
+        TilingSpecification::new(tiling_origin, [2048, 2048].into()),
+        TilingSpecification::new(tiling_origin, [4096, 4096].into()),
         // TilingSpecification::new((0., 0.).into(), [9000, 9000].into()),
     ];
 

--- a/operators/src/adapters/feature_collection_merger.rs
+++ b/operators/src/adapters/feature_collection_merger.rs
@@ -181,11 +181,11 @@ mod tests {
 
         let TypedVectorQueryProcessor::MultiPoint(processor) = source.query_processor().unwrap() else { unreachable!(); };
 
-        let qrect = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((0.0, 0.0).into(), (10.0, 10.0).into()).unwrap(),
-            time_interval: Default::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let qrect = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((0.0, 0.0).into(), (10.0, 10.0).into()).unwrap(),
+            Default::default(),
+            SpatialResolution::zero_point_one(),
+        );
         let cx = MockQueryContext::new((std::mem::size_of::<Coordinate2D>() * 2).into());
 
         let number_of_source_chunks = processor
@@ -252,11 +252,11 @@ mod tests {
 
         let TypedVectorQueryProcessor::Data(processor) = source.query_processor().unwrap() else { unreachable!(); };
 
-        let qrect = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((0.0, 0.0).into(), (0.0, 0.0).into()).unwrap(),
-            time_interval: Default::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let qrect = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((0.0, 0.0).into(), (0.0, 0.0).into()).unwrap(),
+            Default::default(),
+            SpatialResolution::zero_point_one(),
+        );
         let cx = MockQueryContext::new((0).into());
 
         let collections =

--- a/operators/src/adapters/raster_subquery/raster_subquery_adapter.rs
+++ b/operators/src/adapters/raster_subquery/raster_subquery_adapter.rs
@@ -12,10 +12,10 @@ use futures::{
 use futures::{stream::FusedStream, Future};
 use futures::{Stream, StreamExt, TryFutureExt};
 use geoengine_datatypes::primitives::CacheHint;
-use geoengine_datatypes::primitives::{
-    RasterQueryRectangle, SpatialPartition2D, SpatialPartitioned,
+use geoengine_datatypes::primitives::{RasterQueryRectangle, RasterSpatialQueryRectangle};
+use geoengine_datatypes::raster::{
+    EmptyGrid2D, GridBoundingBox2D, GridBounds, GridStep, TilingStrategy,
 };
-use geoengine_datatypes::raster::{EmptyGrid2D, GridBoundingBox2D, GridBounds, GridStep};
 use geoengine_datatypes::{
     primitives::TimeInstance,
     raster::{Blit, Pixel, RasterTile2D, TileInformation},
@@ -130,14 +130,14 @@ where
         query_ctx: &'a dyn QueryContext,
         sub_query: SubQuery,
     ) -> Self {
-        debug_assert!(query_rect_to_answer.spatial_resolution.y > 0.);
-
-        let tiling_strat = tiling_spec.strategy(
-            query_rect_to_answer.spatial_resolution.x,
-            -query_rect_to_answer.spatial_resolution.y,
+        // FIXME: we should not need to create a new tiling strategy here
+        let tiling_strat = TilingStrategy::new(
+            tiling_spec.tile_size_in_pixels,
+            query_rect_to_answer.spatial_query().geo_transform,
         );
 
-        let grid_bounds = tiling_strat.tile_grid_box(query_rect_to_answer.spatial_partition());
+        let grid_bounds = tiling_strat
+            .raster_spatial_query_to_tiling_grid_box(&query_rect_to_answer.spatial_query());
 
         let first_tile_spec = TileInformation {
             global_geo_transform: tiling_strat.geo_transform,
@@ -167,7 +167,7 @@ where
     where
         Self: Stream<Item = Result<Option<RasterTile2D<PixelType>>>> + 'a,
     {
-        let grid_bounds = self.grid_bounds.clone();
+        let grid_bounds = self.grid_bounds;
         let global_geo_transform = self.current_tile_spec.global_geo_transform;
         let tile_shape = self.current_tile_spec.tile_size_in_pixels;
 
@@ -204,8 +204,10 @@ impl<'a, PixelType, RasterProcessorType, SubQuery> FusedStream
     for RasterSubQueryAdapter<'a, PixelType, RasterProcessorType, SubQuery>
 where
     PixelType: Pixel,
-    RasterProcessorType:
-        QueryProcessor<Output = RasterTile2D<PixelType>, SpatialBounds = SpatialPartition2D>,
+    RasterProcessorType: QueryProcessor<
+        Output = RasterTile2D<PixelType>,
+        SpatialQuery = RasterSpatialQueryRectangle,
+    >,
     SubQuery: SubQueryTileAggregator<'a, PixelType> + 'static,
 {
     fn is_terminated(&self) -> bool {
@@ -217,8 +219,10 @@ impl<'a, PixelType, RasterProcessorType, SubQuery> Stream
     for RasterSubQueryAdapter<'a, PixelType, RasterProcessorType, SubQuery>
 where
     PixelType: Pixel,
-    RasterProcessorType:
-        QueryProcessor<Output = RasterTile2D<PixelType>, SpatialBounds = SpatialPartition2D>,
+    RasterProcessorType: QueryProcessor<
+        Output = RasterTile2D<PixelType>,
+        SpatialQuery = RasterSpatialQueryRectangle,
+    >,
     SubQuery: SubQueryTileAggregator<'a, PixelType> + 'static,
 {
     type Item = Result<Option<RasterTile2D<PixelType>>>;
@@ -535,11 +539,11 @@ where
         query_rect: RasterQueryRectangle,
         start_time: TimeInstance,
     ) -> Result<Option<RasterQueryRectangle>> {
-        Ok(Some(RasterQueryRectangle {
-            spatial_bounds: tile_info.spatial_partition(),
-            time_interval: TimeInterval::new_instant(start_time)?,
-            spatial_resolution: query_rect.spatial_resolution,
-        }))
+        Ok(Some(RasterQueryRectangle::with_grid_bounds_and_resolution(
+            tile_info.global_pixel_bounds(),
+            query_rect.spatial_query().geo_transform,
+            TimeInterval::new_instant(start_time)?,
+        )))
     }
 
     fn fold_method(&self) -> Self::FoldMethod {
@@ -684,11 +688,12 @@ mod tests {
             shape_array: [2, 2],
         };
 
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 1.).into(), (3., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 10),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 1.).into(), (3., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 10),
+        );
 
         let query_ctx = MockQueryContext::test_default();
         let tiling_strat = exe_ctx.tiling_specification;

--- a/operators/src/adapters/raster_time.rs
+++ b/operators/src/adapters/raster_time.rs
@@ -5,7 +5,9 @@ use futures::future::{self, BoxFuture, Join, JoinAll};
 use futures::stream::{BoxStream, FusedStream, Zip};
 use futures::{ready, StreamExt};
 use futures::{Future, Stream};
-use geoengine_datatypes::primitives::{RasterQueryRectangle, SpatialPartition2D, TimeInterval};
+use geoengine_datatypes::primitives::{
+    RasterQueryRectangle, SpatialPartition2D, SpatialPartitioned, TimeInterval,
+};
 use geoengine_datatypes::raster::{GridSize, Pixel, RasterTile2D, TileInformation, TilingStrategy};
 use pin_project::pin_project;
 use std::cmp::min;
@@ -284,7 +286,7 @@ where
                             let num_spatial_tiles = *num_spatial_tiles.get_or_insert_with(|| {
                                 Self::number_of_tiles_in_partition(
                                     &tile_a.tile_information(),
-                                    query_rect.spatial_bounds,
+                                    query_rect.spatial_query().spatial_partition(), // TODO: this should be calculated from the tile grid bounds and not the spatial bounds.
                                 )
                             });
 
@@ -437,7 +439,7 @@ where
                     let num_spatial_tiles = *num_spatial_tiles.get_or_insert_with(|| {
                         Self::number_of_tiles_in_partition(
                             &tiles[0].tile_information(),
-                            query_rect.spatial_bounds,
+                            query_rect.spatial_query().spatial_partition(),
                         )
                     });
 
@@ -720,11 +722,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 10),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 10),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp1 = mrs1
@@ -941,11 +944,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 10),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 10),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp1 = mrs1
@@ -1142,11 +1146,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 10),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 10),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp1 = mrs1
@@ -1327,11 +1332,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 10),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 10),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp1 = mrs1
@@ -1488,11 +1494,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(2, 4),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(2, 4),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp1 = mrs1
@@ -1648,11 +1655,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(2, 4),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(2, 4),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp1 = mrs1
@@ -1819,11 +1827,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(2, 8),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(2, 8),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp1 = mrs1
@@ -1999,12 +2008,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(2, 8),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(2, 8),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp1 = mrs1
@@ -2159,11 +2168,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(1, 3),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(1, 3),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let query_processor_a = raster_source_a

--- a/operators/src/mock/mock_dataset_data_source.rs
+++ b/operators/src/mock/mock_dataset_data_source.rs
@@ -211,11 +211,11 @@ mod tests {
         let typed_processor = initialized.query_processor();
         let Ok(TypedVectorQueryProcessor::MultiPoint(point_processor)) = typed_processor else { panic!() };
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((0., 0.).into(), (4., 4.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((0., 0.).into(), (4., 4.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
         let ctx = MockQueryContext::new((2 * std::mem::size_of::<Coordinate2D>()).into());
 
         let stream = point_processor.query(query_rectangle, &ctx).await.unwrap();

--- a/operators/src/mock/mock_feature_collection_source.rs
+++ b/operators/src/mock/mock_feature_collection_source.rs
@@ -375,11 +375,11 @@ mod tests {
 
         let Ok(TypedVectorQueryProcessor::MultiPoint(processor)) = source.query_processor() else { panic!() };
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((0., 0.).into(), (4., 4.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((0., 0.).into(), (4., 4.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
         let ctx = MockQueryContext::new((2 * std::mem::size_of::<Coordinate2D>()).into());
 
         let stream = processor.query(query_rectangle, &ctx).await.unwrap();

--- a/operators/src/mock/mock_point_source.rs
+++ b/operators/src/mock/mock_point_source.rs
@@ -11,8 +11,7 @@ use async_trait::async_trait;
 use futures::stream::{self, BoxStream, StreamExt};
 use geoengine_datatypes::collections::VectorDataType;
 use geoengine_datatypes::dataset::NamedData;
-use geoengine_datatypes::primitives::CacheHint;
-use geoengine_datatypes::primitives::VectorQueryRectangle;
+use geoengine_datatypes::primitives::{CacheHint, VectorQueryRectangle};
 use geoengine_datatypes::{
     collections::MultiPointCollection,
     primitives::{Coordinate2D, TimeInterval},
@@ -34,10 +33,12 @@ impl VectorQueryProcessor for MockPointSourceProcessor {
         ctx: &'a dyn QueryContext,
     ) -> Result<BoxStream<'a, Result<Self::VectorType>>> {
         let chunk_size = usize::from(ctx.chunk_byte_size()) / std::mem::size_of::<Coordinate2D>();
-        let bounding_box = query.spatial_bounds;
+        let spatial_query = query.spatial_query();
 
         Ok(stream::iter(&self.points)
-            .filter(move |&coord| std::future::ready(bounding_box.contains_coordinate(coord)))
+            .filter(move |&coord| {
+                std::future::ready(spatial_query.spatial_bounds.contains_coordinate(coord))
+            })
             .chunks(chunk_size)
             .map(move |chunk| {
                 Ok(MultiPointCollection::from_data(
@@ -158,11 +159,11 @@ mod tests {
         let typed_processor = initialized.query_processor();
         let Ok(TypedVectorQueryProcessor::MultiPoint(point_processor)) = typed_processor else { panic!() };
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((0., 0.).into(), (4., 4.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((0., 0.).into(), (4., 4.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
         let ctx = MockQueryContext::new((2 * std::mem::size_of::<Coordinate2D>()).into());
 
         let stream = point_processor.query(query_rectangle, &ctx).await.unwrap();

--- a/operators/src/plot/box_plot.rs
+++ b/operators/src/plot/box_plot.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use futures::StreamExt;
 use geoengine_datatypes::primitives::{
-    partitions_extent, time_interval_extent, AxisAlignedRectangle, BoundingBox2D,
-    PlotQueryRectangle, VectorQueryRectangle,
+    partitions_extent, time_interval_extent, AxisAlignedRectangle, BoundingBox2D, Coordinate2D,
+    PlotQueryRectangle, RasterQueryRectangle, VectorQueryRectangle,
 };
 use num_traits::AsPrimitive;
 use serde::{Deserialize, Serialize};
@@ -305,7 +305,12 @@ impl BoxPlotRasterQueryProcessor {
         call_on_generic_raster_processor!(input, processor => {
 
 
-            let mut stream = processor.query(query.into(), ctx).await?;
+            let raster_query_rect = RasterQueryRectangle::with_vector_query_and_grid_origin(
+                query,
+                Coordinate2D::default() // FIXME: this is the default tiling specification origin. The actual origin is not known here. It should be derived from the input result descriptor!
+            );
+
+            let mut stream = processor.query(raster_query_rect, ctx).await?;
             let mut accum = BoxPlotAccum::new(name);
 
             while let Some(tile) = stream.next().await {
@@ -613,12 +618,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -679,12 +683,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -788,12 +791,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -839,12 +841,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -892,12 +893,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -971,12 +971,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -1040,11 +1039,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., -3.).into(), (2., 0.).into()).unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., -3.).into(), (2., 0.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -1109,12 +1108,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -1175,15 +1173,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::new_instant(DateTime::new_utc(
-                        2013, 12, 1, 12, 0, 0,
-                    ))
-                    .unwrap(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::new_instant(DateTime::new_utc(2013, 12, 1, 12, 0, 0)).unwrap(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::test_default(),
             )
             .await
@@ -1257,14 +1251,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., -4.).into(), (2., 0.).into()).unwrap(),
-                    time_interval: TimeInterval::new_instant(DateTime::new_utc(
-                        2013, 12, 1, 12, 0, 0,
-                    ))
-                    .unwrap(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., -4.).into(), (2., 0.).into()).unwrap(),
+                    TimeInterval::new_instant(DateTime::new_utc(2013, 12, 1, 12, 0, 0)).unwrap(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::test_default(),
             )
             .await
@@ -1331,14 +1322,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., -4.).into(), (2., 0.).into()).unwrap(),
-                    time_interval: TimeInterval::new_instant(DateTime::new_utc(
-                        2013, 12, 1, 12, 0, 0,
-                    ))
-                    .unwrap(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., -4.).into(), (2., 0.).into()).unwrap(),
+                    TimeInterval::new_instant(DateTime::new_utc(2013, 12, 1, 12, 0, 0)).unwrap(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::test_default(),
             )
             .await
@@ -1417,15 +1405,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::new_instant(DateTime::new_utc(
-                        2013, 12, 1, 12, 0, 0,
-                    ))
-                    .unwrap(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::new_instant(DateTime::new_utc(2013, 12, 1, 12, 0, 0)).unwrap(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::test_default(),
             )
             .await

--- a/operators/src/plot/class_histogram.rs
+++ b/operators/src/plot/class_histogram.rs
@@ -14,8 +14,8 @@ use futures::StreamExt;
 use geoengine_datatypes::collections::FeatureCollectionInfos;
 use geoengine_datatypes::plots::{BarChart, Plot, PlotData};
 use geoengine_datatypes::primitives::{
-    AxisAlignedRectangle, BoundingBox2D, ClassificationMeasurement, FeatureDataType, Measurement,
-    VectorQueryRectangle,
+    AxisAlignedRectangle, BoundingBox2D, ClassificationMeasurement, Coordinate2D, FeatureDataType,
+    Measurement, PlotQueryRectangle, RasterQueryRectangle,
 };
 use num_traits::AsPrimitive;
 use serde::{Deserialize, Serialize};
@@ -246,7 +246,7 @@ impl PlotQueryProcessor for ClassHistogramRasterQueryProcessor {
 
     async fn plot_query<'p>(
         &'p self,
-        query: VectorQueryRectangle,
+        query: PlotQueryRectangle,
         ctx: &'p dyn QueryContext,
     ) -> Result<Self::OutputFormat> {
         self.process(query, ctx).await
@@ -263,7 +263,7 @@ impl PlotQueryProcessor for ClassHistogramVectorQueryProcessor {
 
     async fn plot_query<'p>(
         &'p self,
-        query: VectorQueryRectangle,
+        query: PlotQueryRectangle,
         ctx: &'p dyn QueryContext,
     ) -> Result<Self::OutputFormat> {
         self.process(query, ctx).await
@@ -273,7 +273,7 @@ impl PlotQueryProcessor for ClassHistogramVectorQueryProcessor {
 impl ClassHistogramRasterQueryProcessor {
     async fn process<'p>(
         &'p self,
-        query: VectorQueryRectangle,
+        query: PlotQueryRectangle,
         ctx: &'p dyn QueryContext,
     ) -> Result<<ClassHistogramRasterQueryProcessor as PlotQueryProcessor>::OutputFormat> {
         let mut class_counts: HashMap<u8, u64> = self
@@ -283,8 +283,13 @@ impl ClassHistogramRasterQueryProcessor {
             .map(|key| (*key, 0))
             .collect();
 
+        let raster_query_rect = RasterQueryRectangle::with_vector_query_and_grid_origin(
+            query,
+            Coordinate2D::default(), // FIXME: this is the default tiling specification origin. The actual origin is not known here. It should be derived from the input result descriptor!
+        );
+
         call_on_generic_raster_processor!(&self.input, processor => {
-            let mut query = processor.query(query.into(), ctx).await?;
+            let mut query = processor.query(raster_query_rect, ctx).await?;
 
             while let Some(tile) = query.next().await {
                 match tile?.grid_array {
@@ -330,7 +335,7 @@ impl ClassHistogramRasterQueryProcessor {
 impl ClassHistogramVectorQueryProcessor {
     async fn process<'p>(
         &'p self,
-        query: VectorQueryRectangle,
+        query: PlotQueryRectangle,
         ctx: &'p dyn QueryContext,
     ) -> Result<<ClassHistogramRasterQueryProcessor as PlotQueryProcessor>::OutputFormat> {
         let mut class_counts: HashMap<u8, u64> = self
@@ -404,6 +409,7 @@ mod tests {
     use geoengine_datatypes::dataset::{DataId, DatasetId, NamedData};
     use geoengine_datatypes::primitives::{
         BoundingBox2D, DateTime, FeatureData, NoGeometry, SpatialResolution, TimeInterval,
+        VectorQueryRectangle,
     };
     use geoengine_datatypes::primitives::{CacheHint, CacheTtlSeconds};
     use geoengine_datatypes::raster::{
@@ -536,11 +542,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., -3.).into(), (2., 0.).into()).unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., -3.).into(), (2., 0.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -620,12 +626,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -704,12 +709,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -906,11 +910,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., -3.).into(), (2., 0.).into()).unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., -3.).into(), (2., 0.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -967,12 +971,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -1029,12 +1032,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -1106,14 +1108,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., -3.).into(), (2., 0.).into()).unwrap(),
-                    time_interval: TimeInterval::new_instant(DateTime::new_utc(
-                        2013, 12, 1, 12, 0, 0,
-                    ))
-                    .unwrap(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., -3.).into(), (2., 0.).into()).unwrap(),
+                    TimeInterval::new_instant(DateTime::new_utc(2013, 12, 1, 12, 0, 0)).unwrap(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await

--- a/operators/src/plot/histogram.rs
+++ b/operators/src/plot/histogram.rs
@@ -16,8 +16,8 @@ use futures::stream::BoxStream;
 use futures::{StreamExt, TryFutureExt};
 use geoengine_datatypes::plots::{Plot, PlotData};
 use geoengine_datatypes::primitives::{
-    AxisAlignedRectangle, BoundingBox2D, DataRef, FeatureDataRef, FeatureDataType, Geometry,
-    Measurement, VectorQueryRectangle,
+    AxisAlignedRectangle, BoundingBox2D, Coordinate2D, DataRef, FeatureDataRef, FeatureDataType,
+    Geometry, Measurement, PlotQueryRectangle, RasterQueryRectangle, VectorQueryRectangle,
 };
 use geoengine_datatypes::raster::{Pixel, RasterTile2D};
 use geoengine_datatypes::{
@@ -295,7 +295,7 @@ impl PlotQueryProcessor for HistogramRasterQueryProcessor {
 
     async fn plot_query<'p>(
         &'p self,
-        query: VectorQueryRectangle,
+        query: PlotQueryRectangle,
         ctx: &'p dyn QueryContext,
     ) -> Result<Self::OutputFormat> {
         self.preprocess(query, ctx)
@@ -322,7 +322,7 @@ impl PlotQueryProcessor for HistogramVectorQueryProcessor {
 
     async fn plot_query<'p>(
         &'p self,
-        query: VectorQueryRectangle,
+        query: PlotQueryRectangle,
         ctx: &'p dyn QueryContext,
     ) -> Result<Self::OutputFormat> {
         self.preprocess(query, ctx)
@@ -342,7 +342,7 @@ impl PlotQueryProcessor for HistogramVectorQueryProcessor {
 impl HistogramRasterQueryProcessor {
     async fn preprocess<'p>(
         &'p self,
-        query: VectorQueryRectangle,
+        query: PlotQueryRectangle,
         ctx: &'p dyn QueryContext,
     ) -> Result<HistogramMetadata> {
         async fn process_metadata<T: Pixel>(
@@ -368,16 +368,20 @@ impl HistogramRasterQueryProcessor {
         }
 
         // TODO: compute only number of buckets if possible
+        let raster_query_rect = RasterQueryRectangle::with_vector_query_and_grid_origin(
+            query,
+            Coordinate2D::default(), // FIXME: this is the default tiling specification origin. The actual origin is not known here. It should be derived from the input result descriptor!
+        );
 
         call_on_generic_raster_processor!(&self.input, processor => {
-            process_metadata(processor.query(query.into(), ctx).await?, self.metadata).await
+            process_metadata(processor.query(raster_query_rect, ctx).await?, self.metadata).await
         })
     }
 
     async fn process<'p>(
         &'p self,
         metadata: HistogramMetadata,
-        query: VectorQueryRectangle,
+        query: PlotQueryRectangle,
         ctx: &'p dyn QueryContext,
     ) -> Result<<HistogramRasterQueryProcessor as PlotQueryProcessor>::OutputFormat> {
         let mut histogram = geoengine_datatypes::plots::Histogram::builder(
@@ -389,8 +393,13 @@ impl HistogramRasterQueryProcessor {
         .build()
         .map_err(Error::from)?;
 
+        let raster_query_rect = RasterQueryRectangle::with_vector_query_and_grid_origin(
+            query,
+            Coordinate2D::default(), // FIXME: this is the default tiling specification origin. The actual origin is not known here. It should be derived from the input result descriptor!
+        );
+
         call_on_generic_raster_processor!(&self.input, processor => {
-            let mut query = processor.query(query.into(), ctx).await?;
+            let mut query = processor.query(raster_query_rect, ctx).await?;
 
             while let Some(tile) = query.next().await {
 
@@ -848,11 +857,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., -3.).into(), (2., 0.).into()).unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., -3.).into(), (2., 0.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -902,11 +911,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., -3.).into(), (2., 0.).into()).unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., -3.).into(), (2., 0.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -965,12 +974,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -1035,12 +1043,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -1234,11 +1241,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., -3.).into(), (2., 0.).into()).unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., -3.).into(), (2., 0.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -1292,12 +1299,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -1357,12 +1363,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -1439,14 +1444,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., -3.).into(), (2., 0.).into()).unwrap(),
-                    time_interval: TimeInterval::new_instant(DateTime::new_utc(
-                        2013, 12, 1, 12, 0, 0,
-                    ))
-                    .unwrap(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., -3.).into(), (2., 0.).into()).unwrap(),
+                    TimeInterval::new_instant(DateTime::new_utc(2013, 12, 1, 12, 0, 0)).unwrap(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await

--- a/operators/src/plot/pie_chart.rs
+++ b/operators/src/plot/pie_chart.rs
@@ -295,7 +295,8 @@ mod tests {
     use geoengine_datatypes::dataset::{DataId, DatasetId, NamedData};
     use geoengine_datatypes::primitives::CacheTtlSeconds;
     use geoengine_datatypes::primitives::{
-        BoundingBox2D, FeatureData, FeatureDataType, NoGeometry, SpatialResolution, TimeInterval,
+        BoundingBox2D, FeatureData, FeatureDataType, NoGeometry, PlotQueryRectangle,
+        SpatialResolution, TimeInterval,
     };
     use geoengine_datatypes::spatial_reference::SpatialReference;
     use geoengine_datatypes::util::test::TestDefault;
@@ -396,12 +397,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -472,12 +472,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -618,12 +617,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -666,12 +664,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -746,12 +743,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -810,12 +806,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await

--- a/operators/src/plot/scatter_plot.rs
+++ b/operators/src/plot/scatter_plot.rs
@@ -284,7 +284,7 @@ mod tests {
     use serde_json::json;
 
     use geoengine_datatypes::primitives::{
-        BoundingBox2D, FeatureData, NoGeometry, SpatialResolution, TimeInterval,
+        BoundingBox2D, FeatureData, NoGeometry, PlotQueryRectangle, SpatialResolution, TimeInterval,
     };
     use geoengine_datatypes::{collections::DataCollection, primitives::MultiPoint};
 
@@ -375,12 +375,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -452,12 +451,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -637,12 +635,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -690,12 +687,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -745,12 +741,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -826,12 +821,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await

--- a/operators/src/plot/temporal_raster_mean_plot.rs
+++ b/operators/src/plot/temporal_raster_mean_plot.rs
@@ -11,7 +11,7 @@ use futures::stream::BoxStream;
 use futures::StreamExt;
 use geoengine_datatypes::plots::{AreaLineChart, Plot, PlotData};
 use geoengine_datatypes::primitives::{
-    Measurement, TimeInstance, TimeInterval, VectorQueryRectangle,
+    Coordinate2D, Measurement, PlotQueryRectangle, RasterQueryRectangle, TimeInstance, TimeInterval,
 };
 use geoengine_datatypes::raster::{Pixel, RasterTile2D};
 use serde::{Deserialize, Serialize};
@@ -129,11 +129,16 @@ impl<P: Pixel> PlotQueryProcessor for MeanRasterPixelValuesOverTimeQueryProcesso
 
     async fn plot_query<'a>(
         &'a self,
-        query: VectorQueryRectangle,
+        query: PlotQueryRectangle,
         ctx: &'a dyn QueryContext,
     ) -> Result<Self::OutputFormat> {
+        let raster_query_rect = RasterQueryRectangle::with_vector_query_and_grid_origin(
+            query,
+            Coordinate2D::default(), // FIXME: this is the default tiling specification origin. The actual origin is not known here. It should be derived from the input result descriptor!
+        );
+
         let means = Self::calculate_means(
-            self.raster.query(query.into(), ctx).await?,
+            self.raster.query(raster_query_rect, ctx).await?,
             self.time_position,
         )
         .await?;
@@ -347,12 +352,11 @@ mod tests {
 
         let result = processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -488,12 +492,11 @@ mod tests {
 
         let result = processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::one(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await

--- a/operators/src/plot/temporal_vector_line_plot.rs
+++ b/operators/src/plot/temporal_vector_line_plot.rs
@@ -278,6 +278,7 @@ impl<const LENGTH: usize> FeatureAttributeValues<LENGTH> {
 mod tests {
     use super::*;
     use geoengine_datatypes::primitives::CacheHint;
+    use geoengine_datatypes::primitives::PlotQueryRectangle;
     use geoengine_datatypes::util::test::TestDefault;
     use geoengine_datatypes::{
         collections::MultiPointCollection,
@@ -354,12 +355,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::new(0.1, 0.1).unwrap(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::new(0.1, 0.1).unwrap(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -502,12 +502,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::new(0.1, 0.1).unwrap(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::new(0.1, 0.1).unwrap(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -638,12 +637,11 @@ mod tests {
 
         let result = query_processor
             .plot_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::new(0.1, 0.1).unwrap(),
-                },
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::new(0.1, 0.1).unwrap(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await

--- a/operators/src/pro/cache/cache_chunks.rs
+++ b/operators/src/pro/cache/cache_chunks.rs
@@ -373,11 +373,12 @@ macro_rules! impl_cache_result_check {
         {
             fn cache_element_hit(&self, query_rect: &VectorQueryRectangle) -> bool {
                 let Some(bbox) = self.bbox() else {return false;};
-
                 let Some(time_bounds) = self.time_bounds() else {return false;};
 
-                (bbox == query_rect.spatial_bounds
-                    || bbox.intersects_bbox(&query_rect.spatial_bounds))
+                let query_spatial_query = query_rect.spatial_query();
+
+                (bbox == query_spatial_query.spatial_bounds
+                    || bbox.intersects_bbox(&query_spatial_query.spatial_bounds))
                     && (time_bounds == query_rect.time_interval
                         || time_bounds.intersects(&query_rect.time_interval))
             }
@@ -386,9 +387,11 @@ macro_rules! impl_cache_result_check {
                 &self,
                 query_rect: &VectorQueryRectangle,
             ) -> Result<Self, CacheError> {
+                let query_spatial_query = query_rect.spatial_query();
+
                 let geoms_filter_bools = self.geometries().map(|g| {
                     g.bbox()
-                        .map(|bbox| bbox.intersects_bbox(&query_rect.spatial_bounds))
+                        .map(|bbox| bbox.intersects_bbox(&query_spatial_query.spatial_bounds))
                         .unwrap_or(false)
                 });
 

--- a/operators/src/pro/ml/xgboost.rs
+++ b/operators/src/pro/ml/xgboost.rs
@@ -6,8 +6,8 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use geoengine_datatypes::primitives::CacheHint;
 use geoengine_datatypes::primitives::{
-    partitions_extent, time_interval_extent, Measurement, RasterQueryRectangle, SpatialPartition2D,
-    SpatialResolution,
+    partitions_extent, time_interval_extent, Measurement, RasterQueryRectangle,
+    RasterSpatialQueryRectangle, SpatialResolution,
 };
 use geoengine_datatypes::raster::{
     BaseTile, Grid2D, GridOrEmpty, GridShape, GridShapeAccess, GridSize, RasterDataType,
@@ -347,10 +347,10 @@ fn process_tile(
 #[async_trait]
 impl<Q> QueryProcessor for XgboostProcessor<Q>
 where
-    Q: QueryProcessor<Output = RasterTile2D<f32>, SpatialBounds = SpatialPartition2D>,
+    Q: QueryProcessor<Output = RasterTile2D<f32>, SpatialQuery = RasterSpatialQueryRectangle>,
 {
     type Output = RasterTile2D<PixelOut>;
-    type SpatialBounds = SpatialPartition2D;
+    type SpatialQuery = RasterSpatialQueryRectangle;
 
     async fn _query<'a>(
         &'a self,
@@ -594,11 +594,12 @@ mod tests {
 
         let processor = op.query_processor().unwrap().get_f32().unwrap();
 
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new((0., 5.).into(), (10., 0.).into()).unwrap(),
-            time_interval: TimeInterval::new_unchecked(0, 1),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new((0., 5.).into(), (10., 0.).into()).unwrap(),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 1),
+        );
 
         let query_ctx = MockQueryContext::test_default();
 
@@ -904,11 +905,12 @@ mod tests {
 
         let processor = op.query_processor().unwrap().get_f32().unwrap();
 
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new((0., 5.).into(), (5., 0.).into()).unwrap(),
-            time_interval: TimeInterval::new_unchecked(0, 1),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new((0., 5.).into(), (5., 0.).into()).unwrap(),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 1),
+        );
 
         let query_ctx = MockQueryContext::test_default();
 

--- a/operators/src/processing/circle_merging_quadtree/operator.rs
+++ b/operators/src/processing/circle_merging_quadtree/operator.rs
@@ -8,8 +8,8 @@ use geoengine_datatypes::collections::{
 };
 use geoengine_datatypes::primitives::CacheHint;
 use geoengine_datatypes::primitives::{
-    BoundingBox2D, Circle, FeatureDataType, FeatureDataValue, Measurement, MultiPoint,
-    MultiPointAccess, VectorQueryRectangle,
+    Circle, FeatureDataType, FeatureDataValue, Measurement, MultiPoint, MultiPointAccess,
+    SpatialBounded, VectorQueryRectangle, VectorSpatialQueryRectangle,
 };
 use serde::{Deserialize, Serialize};
 use snafu::ensure;
@@ -362,7 +362,7 @@ struct GridFoldState {
 #[async_trait]
 impl QueryProcessor for VisualPointClusteringProcessor {
     type Output = MultiPointCollection;
-    type SpatialBounds = BoundingBox2D;
+    type SpatialQuery = VectorSpatialQueryRectangle;
 
     async fn _query<'a>(
         &'a self,
@@ -378,11 +378,14 @@ impl QueryProcessor for VisualPointClusteringProcessor {
             .map(|(name, column_info)| (name.clone(), column_info.data_type))
             .collect();
 
-        let joint_resolution = f64::max(query.spatial_resolution.x, query.spatial_resolution.y);
+        let joint_resolution = f64::max(
+            query.spatial_query.spatial_resolution.x,
+            query.spatial_query.spatial_resolution.y,
+        );
         let scaled_radius_model = self.radius_model.with_scaled_radii(joint_resolution)?;
 
         let initial_grid_fold_state = Result::<GridFoldState>::Ok(GridFoldState {
-            grid: Grid::new(query.spatial_bounds, scaled_radius_model),
+            grid: Grid::new(query.spatial_query.spatial_bounds(), scaled_radius_model),
             column_mapping: self.attribute_mapping.clone(),
             cache_hint: CacheHint::max_duration(),
         });
@@ -455,7 +458,11 @@ impl QueryProcessor for VisualPointClusteringProcessor {
                 cache_hint,
             } = grid?;
 
-            let mut cmq = CircleMergingQuadtree::new(query.spatial_bounds, *grid.radius_model(), 1);
+            let mut cmq = CircleMergingQuadtree::new(
+                query.spatial_query.spatial_bounds(),
+                *grid.radius_model(),
+                1,
+            );
 
             // TODO: worker thread
             for circle_of_points in grid.drain() {
@@ -479,6 +486,7 @@ impl QueryProcessor for VisualPointClusteringProcessor {
 #[cfg(test)]
 mod tests {
     use geoengine_datatypes::collections::ChunksEqualIgnoringCacheHint;
+    use geoengine_datatypes::primitives::BoundingBox2D;
     use geoengine_datatypes::primitives::CacheHint;
     use geoengine_datatypes::primitives::FeatureData;
     use geoengine_datatypes::primitives::SpatialResolution;
@@ -534,11 +542,11 @@ mod tests {
 
         let query_context = MockQueryContext::test_default();
 
-        let qrect = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::new(0.1, 0.1).unwrap(),
-        };
+        let qrect = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::new(0.1, 0.1).unwrap(),
+        );
 
         let query = query_processor.query(qrect, &query_context).await.unwrap();
 
@@ -615,11 +623,11 @@ mod tests {
 
         let query_context = MockQueryContext::test_default();
 
-        let qrect = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::new(0.1, 0.1).unwrap(),
-        };
+        let qrect = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::new(0.1, 0.1).unwrap(),
+        );
 
         let query = query_processor.query(qrect, &query_context).await.unwrap();
 
@@ -697,11 +705,11 @@ mod tests {
 
         let query_context = MockQueryContext::test_default();
 
-        let qrect = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::new(0.1, 0.1).unwrap(),
-        };
+        let qrect = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::new(0.1, 0.1).unwrap(),
+        );
 
         let query = query_processor.query(qrect, &query_context).await.unwrap();
 
@@ -787,11 +795,11 @@ mod tests {
 
         let query_context = MockQueryContext::test_default();
 
-        let qrect = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::new(0.1, 0.1).unwrap(),
-        };
+        let qrect = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::new(0.1, 0.1).unwrap(),
+        );
 
         let query = query_processor.query(qrect, &query_context).await.unwrap();
 
@@ -892,11 +900,11 @@ mod tests {
 
         let query_context = MockQueryContext::test_default();
 
-        let qrect = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::new(0.1, 0.1).unwrap(),
-        };
+        let qrect = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::new(0.1, 0.1).unwrap(),
+        );
 
         let query = query_processor.query(qrect, &query_context).await.unwrap();
 

--- a/operators/src/processing/column_range_filter.rs
+++ b/operators/src/processing/column_range_filter.rs
@@ -14,7 +14,7 @@ use geoengine_datatypes::collections::{
     FeatureCollection, FeatureCollectionInfos, FeatureCollectionModifications,
 };
 use geoengine_datatypes::primitives::{
-    BoundingBox2D, FeatureDataType, FeatureDataValue, Geometry, VectorQueryRectangle,
+    FeatureDataType, FeatureDataValue, Geometry, VectorQueryRectangle, VectorSpatialQueryRectangle,
 };
 use geoengine_datatypes::util::arrow::ArrowTyped;
 use serde::{Deserialize, Serialize};
@@ -116,7 +116,7 @@ where
     G: Geometry + ArrowTyped + Sync + Send + 'static,
 {
     type Output = FeatureCollection<G>;
-    type SpatialBounds = BoundingBox2D;
+    type SpatialQuery = VectorSpatialQueryRectangle;
 
     async fn _query<'a>(
         &'a self,
@@ -273,11 +273,11 @@ mod tests {
 
         let Ok(TypedVectorQueryProcessor::MultiPoint(point_processor)) = initialized.query_processor() else { panic!(); };
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((0., 0.).into(), (4., 4.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((0., 0.).into(), (4., 4.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
 
         let ctx = MockQueryContext::new((2 * std::mem::size_of::<Coordinate2D>()).into());
 

--- a/operators/src/processing/expression/mod.rs
+++ b/operators/src/processing/expression/mod.rs
@@ -602,7 +602,7 @@ mod tests {
             tile_size_in_pixels,
         };
 
-        let ctx = MockExecutionContext::new_with_tiling_spec(tiling_specification);
+        let exe_ctx = MockExecutionContext::new_with_tiling_spec(tiling_specification);
 
         let raster_a = make_raster(Some(3));
 
@@ -625,7 +625,7 @@ mod tests {
             },
         }
         .boxed()
-        .initialize(WorkflowOperatorPath::initialize_root(), &ctx)
+        .initialize(WorkflowOperatorPath::initialize_root(), &exe_ctx)
         .await
         .unwrap();
 
@@ -634,14 +634,12 @@ mod tests {
         let ctx = MockQueryContext::new(1.into());
         let result_stream = processor
             .query(
-                RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 3.).into(),
-                        (2., 0.).into(),
-                    ),
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    SpatialPartition2D::new_unchecked((0., 3.).into(), (2., 0.).into()),
+                    SpatialResolution::one(),
+                    exe_ctx.tiling_specification.origin_coordinate,
+                    Default::default(),
+                ),
                 &ctx,
             )
             .await
@@ -671,7 +669,7 @@ mod tests {
             tile_size_in_pixels,
         };
 
-        let ctx = MockExecutionContext::new_with_tiling_spec(tiling_specification);
+        let exe_ctx = MockExecutionContext::new_with_tiling_spec(tiling_specification);
 
         let raster_a = make_raster(Some(3));
 
@@ -694,7 +692,7 @@ mod tests {
             },
         }
         .boxed()
-        .initialize(WorkflowOperatorPath::initialize_root(), &ctx)
+        .initialize(WorkflowOperatorPath::initialize_root(), &exe_ctx)
         .await
         .unwrap();
 
@@ -703,14 +701,12 @@ mod tests {
         let ctx = MockQueryContext::new(1.into());
         let result_stream = processor
             .query(
-                RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 3.).into(),
-                        (2., 0.).into(),
-                    ),
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    SpatialPartition2D::new_unchecked((0., 3.).into(), (2., 0.).into()),
+                    SpatialResolution::one(),
+                    exe_ctx.tiling_specification.origin_coordinate,
+                    Default::default(),
+                ),
                 &ctx,
             )
             .await
@@ -740,7 +736,7 @@ mod tests {
             tile_size_in_pixels,
         };
 
-        let ctx = MockExecutionContext::new_with_tiling_spec(tiling_specification);
+        let exe_ctx = MockExecutionContext::new_with_tiling_spec(tiling_specification);
 
         let raster_a = make_raster(None);
         let raster_b = make_raster(None);
@@ -764,7 +760,7 @@ mod tests {
             },
         }
         .boxed()
-        .initialize(WorkflowOperatorPath::initialize_root(), &ctx)
+        .initialize(WorkflowOperatorPath::initialize_root(), &exe_ctx)
         .await
         .unwrap();
 
@@ -773,14 +769,12 @@ mod tests {
         let ctx = MockQueryContext::new(1.into());
         let result_stream = processor
             .query(
-                RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 3.).into(),
-                        (2., 0.).into(),
-                    ),
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    SpatialPartition2D::new_unchecked((0., 3.).into(), (2., 0.).into()),
+                    SpatialResolution::one(),
+                    exe_ctx.tiling_specification.origin_coordinate,
+                    Default::default(),
+                ),
                 &ctx,
             )
             .await
@@ -806,7 +800,7 @@ mod tests {
             tile_size_in_pixels,
         };
 
-        let ctx = MockExecutionContext::new_with_tiling_spec(tiling_specification);
+        let exe_ctx = MockExecutionContext::new_with_tiling_spec(tiling_specification);
 
         let raster_a = make_raster(Some(3));
         let raster_b = make_raster(None);
@@ -837,7 +831,7 @@ mod tests {
             },
         }
         .boxed()
-        .initialize(WorkflowOperatorPath::initialize_root(), &ctx)
+        .initialize(WorkflowOperatorPath::initialize_root(), &exe_ctx)
         .await
         .unwrap();
 
@@ -846,14 +840,12 @@ mod tests {
         let ctx = MockQueryContext::new(1.into());
         let result_stream = processor
             .query(
-                RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 3.).into(),
-                        (2., 0.).into(),
-                    ),
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    SpatialPartition2D::new_unchecked((0., 3.).into(), (2., 0.).into()),
+                    SpatialResolution::one(),
+                    exe_ctx.tiling_specification.origin_coordinate,
+                    Default::default(),
+                ),
                 &ctx,
             )
             .await
@@ -886,7 +878,7 @@ mod tests {
             tile_size_in_pixels,
         };
 
-        let ctx = MockExecutionContext::new_with_tiling_spec(tiling_specification);
+        let exe_ctx = MockExecutionContext::new_with_tiling_spec(tiling_specification);
 
         let raster_a = make_raster(no_data_value_option);
         let raster_b = make_raster(no_data_value_option);
@@ -911,7 +903,7 @@ mod tests {
             },
         }
         .boxed()
-        .initialize(WorkflowOperatorPath::initialize_root(), &ctx)
+        .initialize(WorkflowOperatorPath::initialize_root(), &exe_ctx)
         .await
         .unwrap();
 
@@ -920,14 +912,12 @@ mod tests {
         let ctx = MockQueryContext::new(1.into());
         let result_stream = processor
             .query(
-                RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 3.).into(),
-                        (2., 0.).into(),
-                    ),
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    SpatialPartition2D::new_unchecked((0., 3.).into(), (2., 0.).into()),
+                    SpatialResolution::one(),
+                    exe_ctx.tiling_specification.origin_coordinate,
+                    Default::default(),
+                ),
                 &ctx,
             )
             .await
@@ -965,7 +955,7 @@ mod tests {
             tile_size_in_pixels,
         };
 
-        let ctx = MockExecutionContext::new_with_tiling_spec(tiling_specification);
+        let exe_ctx = MockExecutionContext::new_with_tiling_spec(tiling_specification);
 
         let raster_a = make_raster(no_data_value_option);
         let raster_b = make_raster(no_data_value_option);
@@ -995,7 +985,7 @@ mod tests {
             },
         }
         .boxed()
-        .initialize(WorkflowOperatorPath::initialize_root(), &ctx)
+        .initialize(WorkflowOperatorPath::initialize_root(), &exe_ctx)
         .await
         .unwrap();
 
@@ -1004,14 +994,12 @@ mod tests {
         let ctx = MockQueryContext::new(1.into());
         let result_stream = processor
             .query(
-                RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 3.).into(),
-                        (2., 0.).into(),
-                    ),
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    SpatialPartition2D::new_unchecked((0., 3.).into(), (2., 0.).into()),
+                    SpatialResolution::one(),
+                    exe_ctx.tiling_specification.origin_coordinate,
+                    Default::default(),
+                ),
                 &ctx,
             )
             .await
@@ -1038,7 +1026,7 @@ mod tests {
             tile_size_in_pixels,
         };
 
-        let ectx = MockExecutionContext::new_with_tiling_spec(tiling_specification);
+        let exe_ctx = MockExecutionContext::new_with_tiling_spec(tiling_specification);
 
         let raster_a = make_raster(Some(no_data_value));
 
@@ -1061,7 +1049,7 @@ mod tests {
             },
         }
         .boxed()
-        .initialize(WorkflowOperatorPath::initialize_root(), &ectx)
+        .initialize(WorkflowOperatorPath::initialize_root(), &exe_ctx)
         .await
         .unwrap();
 
@@ -1070,14 +1058,12 @@ mod tests {
         let ctx = MockQueryContext::new(1.into());
         let result_stream = processor
             .query(
-                RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 3.).into(),
-                        (2., 0.).into(),
-                    ),
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    SpatialPartition2D::new_unchecked((0., 3.).into(), (2., 0.).into()),
+                    SpatialResolution::one(),
+                    exe_ctx.tiling_specification.origin_coordinate,
+                    Default::default(),
+                ),
                 &ctx,
             )
             .await
@@ -1182,14 +1168,12 @@ mod tests {
         let ctx = MockQueryContext::new(1.into());
         let result_stream = processor
             .query(
-                RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 3.).into(),
-                        (2., 0.).into(),
-                    ),
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    SpatialPartition2D::new_unchecked((0., 3.).into(), (2., 0.).into()),
+                    SpatialResolution::one(),
+                    ectx.tiling_specification.origin_coordinate,
+                    Default::default(),
+                ),
                 &ctx,
             )
             .await
@@ -1251,14 +1235,12 @@ mod tests {
         let ctx = MockQueryContext::new(1.into());
         let result_stream = processor
             .query(
-                RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 3.).into(),
-                        (2., 0.).into(),
-                    ),
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    SpatialPartition2D::new_unchecked((0., 3.).into(), (2., 0.).into()),
+                    SpatialResolution::one(),
+                    ectx.tiling_specification.origin_coordinate,
+                    Default::default(),
+                ),
                 &ctx,
             )
             .await
@@ -1322,14 +1304,12 @@ mod tests {
         let ctx = MockQueryContext::new(1.into());
         let result_stream = processor
             .query(
-                RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 3.).into(),
-                        (2., 0.).into(),
-                    ),
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    SpatialPartition2D::new_unchecked((0., 3.).into(), (2., 0.).into()),
+                    SpatialResolution::one(),
+                    ectx.tiling_specification.origin_coordinate,
+                    Default::default(),
+                ),
                 &ctx,
             )
             .await

--- a/operators/src/processing/expression/query_processor.rs
+++ b/operators/src/processing/expression/query_processor.rs
@@ -3,7 +3,7 @@ use std::{marker::PhantomData, sync::Arc};
 use async_trait::async_trait;
 use futures::{stream::BoxStream, StreamExt, TryStreamExt};
 use geoengine_datatypes::{
-    primitives::{CacheHint, RasterQueryRectangle, SpatialPartition2D, TimeInterval},
+    primitives::{CacheHint, RasterQueryRectangle, RasterSpatialQueryRectangle, TimeInterval},
     raster::{
         ConvertDataType, FromIndexFnParallel, GeoTransform, GridIdx2D, GridIndexAccess,
         GridOrEmpty, GridOrEmpty2D, GridShape2D, GridShapeAccess, MapElementsParallel, Pixel,
@@ -52,7 +52,7 @@ where
     Tuple: ExpressionTupleProcessor<TO>,
 {
     type Output = RasterTile2D<TO>;
-    type SpatialBounds = SpatialPartition2D;
+    type SpatialQuery = RasterSpatialQueryRectangle;
 
     async fn _query<'b>(
         &'b self,

--- a/operators/src/processing/interpolation/mod.rs
+++ b/operators/src/processing/interpolation/mod.rs
@@ -16,12 +16,12 @@ use futures::stream::BoxStream;
 use futures::{Future, FutureExt, TryFuture, TryFutureExt};
 use geoengine_datatypes::primitives::CacheHint;
 use geoengine_datatypes::primitives::{
-    AxisAlignedRectangle, Coordinate2D, RasterQueryRectangle, SpatialPartition2D,
-    SpatialPartitioned, SpatialResolution, TimeInstance, TimeInterval,
+    AxisAlignedRectangle, Coordinate2D, RasterQueryRectangle, RasterSpatialQueryRectangle,
+    SpatialPartition2D, SpatialPartitioned, SpatialResolution, TimeInstance, TimeInterval,
 };
 use geoengine_datatypes::raster::{
     Bilinear, Blit, EmptyGrid2D, GeoTransform, GridOrEmpty, GridSize, InterpolationAlgorithm,
-    NearestNeighbor, Pixel, RasterTile2D, TileInformation, TilingSpecification,
+    NearestNeighbor, Pixel, RasterTile2D, TileInformation, TilingSpecification, TilingStrategy,
 };
 use rayon::ThreadPool;
 use serde::{Deserialize, Serialize};
@@ -190,12 +190,12 @@ where
 #[async_trait]
 impl<Q, P, I> QueryProcessor for InterploationProcessor<Q, P, I>
 where
-    Q: QueryProcessor<Output = RasterTile2D<P>, SpatialBounds = SpatialPartition2D>,
+    Q: QueryProcessor<Output = RasterTile2D<P>, SpatialQuery = RasterSpatialQueryRectangle>,
     P: Pixel,
     I: InterpolationAlgorithm<P>,
 {
     type Output = RasterTile2D<P>;
-    type SpatialBounds = SpatialPartition2D;
+    type SpatialQuery = RasterSpatialQueryRectangle;
 
     async fn _query<'a>(
         &'a self,
@@ -203,8 +203,9 @@ where
         ctx: &'a dyn QueryContext,
     ) -> Result<BoxStream<'a, Result<Self::Output>>> {
         // do not interpolate if the source resolution is already fine enough
-        if query.spatial_resolution.x >= self.input_resolution.x
-            && query.spatial_resolution.y >= self.input_resolution.y
+        let query_resolution = query.spatial_query().spatial_resolution();
+        if query_resolution.x >= self.input_resolution.x
+            && query_resolution.y >= self.input_resolution.y
         {
             // TODO: should we use the query or the input resolution here?
             return self.source.query(query, ctx).await;
@@ -283,11 +284,14 @@ where
             spatial_bounds.lower_right() + enlarge,
         )?;
 
-        Ok(Some(RasterQueryRectangle {
-            spatial_bounds,
-            time_interval: TimeInterval::new_instant(start_time)?,
-            spatial_resolution: self.input_resolution,
-        }))
+        Ok(Some(
+            RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                spatial_bounds,
+                self.input_resolution,
+                self.tiling_specification.origin_coordinate,
+                TimeInterval::new_instant(start_time)?,
+            ),
+        ))
     }
 
     fn fold_method(&self) -> Self::FoldMethod {
@@ -350,15 +354,23 @@ pub fn create_accu<T: Pixel, I: InterpolationAlgorithm<T>>(
     pool: Arc<ThreadPool>,
     tiling_specification: TilingSpecification,
 ) -> impl Future<Output = Result<InterpolationAccu<T, I>>> {
+    // FIXME: The query origin must match the tiling strategy's origin for now. Also use grid bounds not spatial bounds.
+    assert_eq!(
+        query_rect.spatial_query().geo_transform.origin_coordinate(),
+        tiling_specification.origin_coordinate,
+        "The query origin coordinate must match the tiling strategy's origin for now."
+    );
+
     // create an accumulator as a single tile that fits all the input tiles
     crate::util::spawn_blocking(move || {
-        let tiling = tiling_specification.strategy(
-            query_rect.spatial_resolution.x,
-            -query_rect.spatial_resolution.y,
+        let tiling = TilingStrategy::new(
+            tiling_specification.tile_size_in_pixels,
+            query_rect.spatial_query().geo_transform,
         );
 
+        // TODO: use tile grid bounds not the spatial bounds
         let origin_coordinate = tiling
-            .tile_information_iterator(query_rect.spatial_bounds)
+            .tile_information_iterator_from_grid_bounds(query_rect.spatial_query().grid_bounds)
             .next()
             .expect("a query contains at least one tile")
             .spatial_partition()
@@ -366,11 +378,11 @@ pub fn create_accu<T: Pixel, I: InterpolationAlgorithm<T>>(
 
         let geo_transform = GeoTransform::new(
             origin_coordinate,
-            query_rect.spatial_resolution.x,
-            -query_rect.spatial_resolution.y,
+            query_rect.spatial_query().geo_transform.x_pixel_size(),
+            query_rect.spatial_query().geo_transform.y_pixel_size(),
         );
 
-        let bbox = tiling.tile_grid_box(query_rect.spatial_bounds);
+        let bbox = tiling.tile_grid_box(query_rect.spatial_query().spatial_partition());
 
         let shape = [
             bbox.axis_size_y() * tiling.tile_size_in_pixels.axis_size_y(),
@@ -475,11 +487,12 @@ mod tests {
 
         let processor = operator.query_processor()?.get_i8().unwrap();
 
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 2.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 20),
-            spatial_resolution: SpatialResolution::zero_point_five(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 2.).into(), (4., 0.).into()),
+            SpatialResolution::zero_point_five(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 20),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let result_stream = processor.query(query_rect, &query_ctx).await?;
@@ -629,11 +642,12 @@ mod tests {
 
         let processor = operator.query_processor()?.get_i8().unwrap();
 
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 2.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 20),
-            spatial_resolution: SpatialResolution::zero_point_five(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 2.).into(), (4., 0.).into()),
+            SpatialResolution::zero_point_five(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 20),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let result_stream = processor.query(query_rect, &query_ctx).await?;

--- a/operators/src/processing/line_simplification.rs
+++ b/operators/src/processing/line_simplification.rs
@@ -15,8 +15,8 @@ use geoengine_datatypes::{
     },
     error::{BoxedResultExt, ErrorSource},
     primitives::{
-        BoundingBox2D, Geometry, MultiLineString, MultiLineStringRef, MultiPolygon,
-        MultiPolygonRef, SpatialResolution, VectorQueryRectangle,
+        Geometry, MultiLineString, MultiLineStringRef, MultiPolygon, MultiPolygonRef,
+        SpatialResolution, VectorQueryRectangle, VectorSpatialQueryRectangle,
     },
     util::arrow::ArrowTyped,
 };
@@ -272,7 +272,7 @@ where
 #[async_trait]
 impl<P, G, A> QueryProcessor for LineSimplificationProcessor<P, G, A>
 where
-    P: QueryProcessor<Output = FeatureCollection<G>, SpatialBounds = BoundingBox2D>,
+    P: QueryProcessor<Output = FeatureCollection<G>, SpatialQuery = VectorSpatialQueryRectangle>,
     G: Geometry + ArrowTyped + 'static,
     for<'c> FeatureCollection<G>: IntoGeometryIterator<'c>
         + GeoFeatureCollectionModifications<G, Output = FeatureCollection<G>>,
@@ -282,7 +282,7 @@ where
     >,
 {
     type Output = FeatureCollection<G>;
-    type SpatialBounds = BoundingBox2D;
+    type SpatialQuery = VectorSpatialQueryRectangle;
 
     async fn _query<'a>(
         &'a self,
@@ -293,7 +293,7 @@ where
 
         let epsilon = self
             .epsilon
-            .unwrap_or_else(|| A::derive_epsilon(query.spatial_resolution));
+            .unwrap_or_else(|| A::derive_epsilon(query.spatial_query().spatial_resolution));
 
         let simplified_chunks = chunks.and_then(move |chunk| async move {
             crate::util::spawn_blocking_with_thread_pool(ctx.thread_pool().clone(), move || {
@@ -338,7 +338,8 @@ mod tests {
         },
         dataset::{DataId, DatasetId, NamedData},
         primitives::{
-            FeatureData, MultiLineString, MultiPoint, TimeInterval, {CacheHint, CacheTtlSeconds},
+            BoundingBox2D, CacheHint, CacheTtlSeconds, FeatureData, MultiLineString, MultiPoint,
+            TimeInterval,
         },
         spatial_reference::SpatialReference,
         test_data,
@@ -495,11 +496,11 @@ mod tests {
             .multi_line_string()
             .unwrap();
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((0., 0.).into(), (4., 4.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((0., 0.).into(), (4., 4.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::one(),
+        );
 
         let query_ctx = MockQueryContext::test_default();
 
@@ -613,11 +614,11 @@ mod tests {
         let query_context = MockQueryContext::test_default();
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: query_bbox,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.).unwrap(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    query_bbox,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.).unwrap(),
+                ),
                 &query_context,
             )
             .await

--- a/operators/src/processing/meteosat/mod.rs
+++ b/operators/src/processing/meteosat/mod.rs
@@ -125,22 +125,24 @@ mod test_util {
         let sr = SpatialResolution::new_unchecked(3_000.403_165_817_261, 3_000.403_165_817_261);
         let ul = (0., 0.).into();
         let lr = (599. * sr.x, -599. * sr.y).into();
-        RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked(ul, lr),
-            time_interval: TimeInterval::new_unchecked(
+        RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked(ul, lr),
+            sr,
+            ul, // TODO: should be exe_ctx.tiling_specification.origin_coordinate
+            TimeInterval::new_unchecked(
                 TimeInstance::from(DateTime::new_utc(2012, 12, 12, 12, 0, 0)),
                 TimeInstance::from(DateTime::new_utc(2012, 12, 12, 12, 15, 0)),
             ),
-            spatial_resolution: sr,
-        }
+        )
     }
 
     pub(crate) fn create_mock_query() -> RasterQueryRectangle {
-        RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (2., 0.).into()),
-            time_interval: Default::default(),
-            spatial_resolution: SpatialResolution::one(),
-        }
+        RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (2., 0.).into()),
+            SpatialResolution::one(),
+            (0., 0.).into(), // TODO: should be exe_ctx.tiling_specification.origin_coordinate
+            Default::default(),
+        )
     }
 
     pub(crate) fn create_mock_source<P: Pixel>(

--- a/operators/src/processing/meteosat/radiance.rs
+++ b/operators/src/processing/meteosat/radiance.rs
@@ -11,7 +11,7 @@ use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
 use geoengine_datatypes::primitives::{
     ClassificationMeasurement, ContinuousMeasurement, Measurement, RasterQueryRectangle,
-    SpatialPartition2D,
+    RasterSpatialQueryRectangle,
 };
 use geoengine_datatypes::raster::{
     MapElementsParallel, Pixel, RasterDataType, RasterPropertiesKey, RasterTile2D,
@@ -221,11 +221,11 @@ where
 #[async_trait]
 impl<Q, P> QueryProcessor for RadianceProcessor<Q, P>
 where
-    Q: QueryProcessor<Output = RasterTile2D<P>, SpatialBounds = SpatialPartition2D>,
+    Q: QueryProcessor<Output = RasterTile2D<P>, SpatialQuery = RasterSpatialQueryRectangle>,
     P: Pixel,
 {
     type Output = RasterTile2D<PixelOut>;
-    type SpatialBounds = SpatialPartition2D;
+    type SpatialQuery = RasterSpatialQueryRectangle;
 
     async fn _query<'a>(
         &'a self,

--- a/operators/src/processing/meteosat/reflectance.rs
+++ b/operators/src/processing/meteosat/reflectance.rs
@@ -16,7 +16,7 @@ use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
 use geoengine_datatypes::primitives::{
     ClassificationMeasurement, ContinuousMeasurement, DateTime, Measurement, RasterQueryRectangle,
-    SpatialPartition2D,
+    RasterSpatialQueryRectangle,
 };
 use geoengine_datatypes::raster::{
     GridIdx2D, MapIndexedElementsParallel, RasterDataType, RasterPropertiesKey, RasterTile2D,
@@ -264,10 +264,10 @@ fn calculate_esd(timestamp: &DateTime) -> f64 {
 #[async_trait]
 impl<Q> QueryProcessor for ReflectanceProcessor<Q>
 where
-    Q: QueryProcessor<Output = RasterTile2D<PixelOut>, SpatialBounds = SpatialPartition2D>,
+    Q: QueryProcessor<Output = RasterTile2D<PixelOut>, SpatialQuery = RasterSpatialQueryRectangle>,
 {
     type Output = RasterTile2D<PixelOut>;
-    type SpatialBounds = SpatialPartition2D;
+    type SpatialQuery = RasterSpatialQueryRectangle;
 
     async fn _query<'a>(
         &'a self,

--- a/operators/src/processing/meteosat/temperature.rs
+++ b/operators/src/processing/meteosat/temperature.rs
@@ -16,7 +16,7 @@ use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
 use geoengine_datatypes::primitives::{
     ClassificationMeasurement, ContinuousMeasurement, Measurement, RasterQueryRectangle,
-    SpatialPartition2D,
+    RasterSpatialQueryRectangle,
 };
 use geoengine_datatypes::raster::{
     MapElementsParallel, Pixel, RasterDataType, RasterPropertiesKey, RasterTile2D,
@@ -264,11 +264,11 @@ fn create_lookup_table(channel: &Channel, offset: f64, slope: f64, _pool: &Threa
 #[async_trait]
 impl<Q, P> QueryProcessor for TemperatureProcessor<Q, P>
 where
-    Q: QueryProcessor<Output = RasterTile2D<P>, SpatialBounds = SpatialPartition2D>,
+    Q: QueryProcessor<Output = RasterTile2D<P>, SpatialQuery = RasterSpatialQueryRectangle>,
     P: Pixel,
 {
     type Output = RasterTile2D<PixelOut>;
-    type SpatialBounds = SpatialPartition2D;
+    type SpatialQuery = RasterSpatialQueryRectangle;
 
     async fn _query<'a>(
         &'a self,

--- a/operators/src/processing/neighborhood_aggregate/mod.rs
+++ b/operators/src/processing/neighborhood_aggregate/mod.rs
@@ -12,7 +12,7 @@ use crate::engine::{
 use crate::util::Result;
 use async_trait::async_trait;
 use futures::stream::BoxStream;
-use geoengine_datatypes::primitives::{RasterQueryRectangle, SpatialPartition2D};
+use geoengine_datatypes::primitives::{RasterQueryRectangle, RasterSpatialQueryRectangle};
 use geoengine_datatypes::raster::{
     Grid2D, GridShape2D, GridSize, Pixel, RasterTile2D, TilingSpecification,
 };
@@ -236,13 +236,13 @@ where
 #[async_trait]
 impl<Q, P, A> QueryProcessor for NeighborhoodAggregateProcessor<Q, P, A>
 where
-    Q: QueryProcessor<Output = RasterTile2D<P>, SpatialBounds = SpatialPartition2D>,
+    Q: QueryProcessor<Output = RasterTile2D<P>, SpatialQuery = RasterSpatialQueryRectangle>,
     P: Pixel,
     f64: AsPrimitive<P>,
     A: AggregateFunction + 'static,
 {
     type Output = RasterTile2D<P>;
-    type SpatialBounds = SpatialPartition2D;
+    type SpatialQuery = RasterSpatialQueryRectangle;
 
     async fn _query<'a>(
         &'a self,
@@ -429,11 +429,12 @@ mod tests {
 
         let processor = operator.query_processor().unwrap().get_i8().unwrap();
 
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new((0., 3.).into(), (6., 0.).into()).unwrap(),
-            time_interval: TimeInterval::new_unchecked(0, 20),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new((0., 3.).into(), (6., 0.).into()).unwrap(),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 20),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let result_stream = processor.query(query_rect, &query_ctx).await.unwrap();
@@ -482,11 +483,12 @@ mod tests {
 
         let processor = operator.query_processor().unwrap().get_i8().unwrap();
 
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new((0., 3.).into(), (6., 0.).into()).unwrap(),
-            time_interval: TimeInterval::new_unchecked(0, 20),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new((0., 3.).into(), (6., 0.).into()).unwrap(),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 20),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let result_stream = processor.query(query_rect, &query_ctx).await.unwrap();
@@ -659,12 +661,12 @@ mod tests {
 
         let processor = operator.query_processor().unwrap().get_u8().unwrap();
 
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into())
-                .unwrap(),
-            time_interval: TimeInstance::from(DateTime::new_utc(2014, 1, 1, 0, 0, 0)).into(),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into()).unwrap(),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInstance::from(DateTime::new_utc(2014, 1, 1, 0, 0, 0)).into(),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let colorizer = Colorizer::linear_gradient(
@@ -729,12 +731,12 @@ mod tests {
 
         let processor = operator.query_processor().unwrap().get_u8().unwrap();
 
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into())
-                .unwrap(),
-            time_interval: TimeInstance::from(DateTime::new_utc(2014, 1, 1, 0, 0, 0)).into(),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into()).unwrap(),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInstance::from(DateTime::new_utc(2014, 1, 1, 0, 0, 0)).into(),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         // let result_stream = processor.query(query_rect, &query_ctx).await.unwrap();

--- a/operators/src/processing/point_in_polygon.rs
+++ b/operators/src/processing/point_in_polygon.rs
@@ -450,11 +450,11 @@ mod tests {
 
         let query_processor = operator.query_processor()?.multi_point().unwrap();
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((0., 0.).into(), (10., 10.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((0., 0.).into(), (10., 10.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
         let ctx = MockQueryContext::new(ChunkByteSize::MAX);
 
         let query = query_processor.query(query_rectangle, &ctx).await.unwrap();
@@ -507,11 +507,11 @@ mod tests {
 
         let query_processor = operator.query_processor()?.multi_point().unwrap();
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((0., 0.).into(), (10., 10.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((0., 0.).into(), (10., 10.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
         let ctx = MockQueryContext::new(ChunkByteSize::MAX);
 
         let query = query_processor.query(query_rectangle, &ctx).await.unwrap();
@@ -575,11 +575,11 @@ mod tests {
 
         let query_processor = operator.query_processor()?.multi_point().unwrap();
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((0., 0.).into(), (10., 10.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((0., 0.).into(), (10., 10.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
         let ctx = MockQueryContext::new(ChunkByteSize::MAX);
 
         let query = query_processor.query(query_rectangle, &ctx).await.unwrap();
@@ -664,11 +664,11 @@ mod tests {
 
         let query_processor = operator.query_processor()?.multi_point().unwrap();
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((0., 0.).into(), (10., 10.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((0., 0.).into(), (10., 10.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
 
         let ctx_one_chunk = MockQueryContext::new(ChunkByteSize::MAX);
         let ctx_minimal_chunks = MockQueryContext::new(ChunkByteSize::MIN);
@@ -747,11 +747,11 @@ mod tests {
         .await
         .unwrap();
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((-10., -10.).into(), (10., 10.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((-10., -10.).into(), (10., 10.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
 
         let query_processor = operator.query_processor().unwrap().multi_point().unwrap();
 

--- a/operators/src/processing/raster_scaling.rs
+++ b/operators/src/processing/raster_scaling.rs
@@ -342,11 +342,12 @@ mod tests {
 
         let query_processor = initialized_op.query_processor().unwrap();
 
-        let query = geoengine_datatypes::primitives::RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new((0., 0.).into(), (2., -2.).into()).unwrap(),
-            spatial_resolution: SpatialResolution::one(),
-            time_interval: TimeInterval::default(),
-        };
+        let query = geoengine_datatypes::primitives::RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new((0., 0.).into(), (2., -2.).into()).unwrap(),
+            SpatialResolution::one(),
+            ctx.tiling_specification().origin_coordinate,
+            TimeInterval::default()
+        );
 
         let TypedRasterQueryProcessor::U8(typed_processor) = query_processor else {
             panic!("expected TypedRasterQueryProcessor::U8");
@@ -453,11 +454,12 @@ mod tests {
 
         let query_processor = initialized_op.query_processor().unwrap();
 
-        let query = geoengine_datatypes::primitives::RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new((0., 0.).into(), (2., -2.).into()).unwrap(),
-            spatial_resolution: SpatialResolution::one(),
-            time_interval: TimeInterval::default(),
-        };
+        let query = geoengine_datatypes::primitives::RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new((0., 0.).into(), (2., -2.).into()).unwrap(),
+            SpatialResolution::one(),
+            ctx.tiling_specification().origin_coordinate,
+            TimeInterval::default(),
+        );
 
         let TypedRasterQueryProcessor::U8(typed_processor) = query_processor else {
             panic!("expected TypedRasterQueryProcessor::U8");

--- a/operators/src/processing/raster_type_conversion.rs
+++ b/operators/src/processing/raster_type_conversion.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use futures::{stream::BoxStream, StreamExt, TryFutureExt, TryStreamExt};
 use geoengine_datatypes::{
-    primitives::{RasterQueryRectangle, SpatialPartition2D},
+    primitives::{RasterQueryRectangle, RasterSpatialQueryRectangle},
     raster::{ConvertDataType, Pixel, RasterDataType, RasterTile2D},
 };
 use serde::{Deserialize, Serialize};
@@ -127,7 +127,7 @@ where
     Q: RasterQueryProcessor<RasterType = PIn>,
 {
     type Output = RasterTile2D<POut>;
-    type SpatialBounds = SpatialPartition2D;
+    type SpatialQuery = RasterSpatialQueryRectangle;
 
     async fn _query<'b>(
         &'b self,
@@ -223,11 +223,12 @@ mod tests {
 
         let query_processor = initialized_op.query_processor().unwrap();
 
-        let query = geoengine_datatypes::primitives::RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new((0., 0.).into(), (2., -2.).into()).unwrap(),
-            spatial_resolution: SpatialResolution::one(),
-            time_interval: TimeInterval::default(),
-        };
+        let query = geoengine_datatypes::primitives::RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new((0., 0.).into(), (2., -2.).into()).unwrap(),
+            SpatialResolution::one(),
+            ctx.tiling_specification().origin_coordinate,
+            TimeInterval::default(),
+        );
 
         let TypedRasterQueryProcessor::F32(typed_processor) = query_processor else {
             panic!("expected TypedRasterQueryProcessor::F32");

--- a/operators/src/processing/raster_vector_join/mod.rs
+++ b/operators/src/processing/raster_vector_join/mod.rs
@@ -428,12 +428,11 @@ mod tests {
 
         let result = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::new(0.1, 0.1).unwrap(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::new(0.1, 0.1).unwrap(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -504,12 +503,11 @@ mod tests {
 
         let result = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::new(0.1, 0.1).unwrap(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::new(0.1, 0.1).unwrap(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await
@@ -583,12 +581,11 @@ mod tests {
 
         let result = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into())
-                        .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::new(0.1, 0.1).unwrap(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+                    TimeInterval::default(),
+                    SpatialResolution::new(0.1, 0.1).unwrap(),
+                ),
                 &MockQueryContext::new(ChunkByteSize::MIN),
             )
             .await

--- a/operators/src/processing/reprojection.rs
+++ b/operators/src/processing/reprojection.rs
@@ -22,14 +22,15 @@ use futures::{stream, StreamExt};
 use geoengine_datatypes::{
     collections::FeatureCollection,
     operations::reproject::{
-        reproject_and_unify_bbox, reproject_query, suggest_pixel_size_from_diag_cross_projected,
-        CoordinateProjection, CoordinateProjector, Reproject, ReprojectClipped,
+        reproject_and_unify_bbox, reproject_spatial_query,
+        suggest_pixel_size_from_diag_cross_projected, CoordinateProjection, CoordinateProjector,
+        Reproject, ReprojectClipped,
     },
     primitives::{
-        BoundingBox2D, Geometry, RasterQueryRectangle, SpatialPartition2D, SpatialPartitioned,
-        SpatialResolution, VectorQueryRectangle,
+        Geometry, RasterQueryRectangle, RasterSpatialQueryRectangle, SpatialPartition2D,
+        SpatialResolution, VectorQueryRectangle, VectorSpatialQueryRectangle,
     },
-    raster::{Pixel, RasterTile2D, TilingSpecification},
+    raster::{Pixel, RasterTile2D, TilingSpecification, TilingStrategy},
     spatial_reference::SpatialReference,
     util::arrow::ArrowTyped,
 };
@@ -240,7 +241,13 @@ impl InitializedVectorOperator for InitializedVectorReprojection {
             TypedVectorQueryProcessor::Data(source) => Ok(TypedVectorQueryProcessor::Data(
                 MapQueryProcessor::new(
                     source,
-                    move |query| reproject_query(query, source_srs, target_srs).map_err(From::from),
+                    move |query: VectorQueryRectangle| {
+                        reproject_spatial_query(query.spatial_query(), source_srs, target_srs)
+                            .map(|sqr| {
+                                sqr.map(|x| VectorQueryRectangle::new(x, query.time_interval))
+                            })
+                            .map_err(From::from)
+                    },
                     (),
                 )
                 .boxed(),
@@ -289,19 +296,23 @@ where
 #[async_trait]
 impl<Q, G> QueryProcessor for VectorReprojectionProcessor<Q, G>
 where
-    Q: QueryProcessor<Output = FeatureCollection<G>, SpatialBounds = BoundingBox2D>,
+    Q: QueryProcessor<Output = FeatureCollection<G>, SpatialQuery = VectorSpatialQueryRectangle>,
     FeatureCollection<G>: Reproject<CoordinateProjector, Out = FeatureCollection<G>>,
     G: Geometry + ArrowTyped,
 {
     type Output = FeatureCollection<G>;
-    type SpatialBounds = BoundingBox2D;
+    type SpatialQuery = VectorSpatialQueryRectangle;
 
     async fn _query<'a>(
         &'a self,
         query: VectorQueryRectangle,
         ctx: &'a dyn QueryContext,
     ) -> Result<BoxStream<'a, Result<Self::Output>>> {
-        let rewritten_query = reproject_query(query, self.from, self.to)?;
+        let rewritten_spatial_query =
+            reproject_spatial_query(query.spatial_query(), self.from, self.to)?;
+
+        let rewritten_query =
+            rewritten_spatial_query.map(|rwq| VectorQueryRectangle::new(rwq, query.time_interval));
 
         if let Some(rewritten_query) = rewritten_query {
             Ok(self
@@ -514,11 +525,11 @@ where
 #[async_trait]
 impl<Q, P> QueryProcessor for RasterReprojectionProcessor<Q, P>
 where
-    Q: QueryProcessor<Output = RasterTile2D<P>, SpatialBounds = SpatialPartition2D>,
+    Q: QueryProcessor<Output = RasterTile2D<P>, SpatialQuery = RasterSpatialQueryRectangle>,
     P: Pixel,
 {
     type Output = RasterTile2D<P>;
-    type SpatialBounds = SpatialPartition2D;
+    type SpatialQuery = RasterSpatialQueryRectangle;
 
     async fn _query<'a>(
         &'a self,
@@ -533,7 +544,7 @@ where
             let in_spatial_res = suggest_pixel_size_from_diag_cross_projected(
                 valid_bounds_out,
                 valid_bounds_in,
-                query.spatial_resolution,
+                query.spatial_query().geo_transform.spatial_resolution(),
             )?;
 
             // setup the subquery
@@ -559,11 +570,15 @@ where
         } else {
             log::debug!("No intersection between source data / srs and target srs");
 
-            let tiling_strat = self
-                .tiling_spec
-                .strategy(query.spatial_resolution.x, -query.spatial_resolution.y);
+            // FIXME: we should not need to create a new tiling strategy here
+            let tiling_strat = TilingStrategy::new(
+                self.tiling_spec.tile_size_in_pixels,
+                query.spatial_query().geo_transform,
+            );
 
-            let grid_bounds = tiling_strat.tile_grid_box(query.spatial_partition());
+            let grid_bounds =
+                tiling_strat.raster_spatial_query_to_tiling_grid_box(&query.spatial_query());
+
             Ok(Box::pin(SparseTilesFillAdapter::new(
                 stream::empty(),
                 grid_bounds,
@@ -608,7 +623,7 @@ mod tests {
         dataset::{DataId, DatasetId},
         hashmap,
         primitives::{
-            BoundingBox2D, Measurement, MultiLineString, MultiPoint, MultiPolygon, QueryRectangle,
+            BoundingBox2D, Measurement, MultiLineString, MultiPoint, MultiPolygon,
             SpatialResolution, TimeGranularity, TimeInstance, TimeInterval, TimeStep,
         },
         raster::{Grid, GridShape, GridShape2D, GridSize, RasterDataType, RasterTile2D},
@@ -670,15 +685,15 @@ mod tests {
 
         let query_processor = query_processor.multi_point().unwrap();
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new(
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new(
                 (COLOGNE_EPSG_4326.x, MARBURG_EPSG_4326.y).into(),
                 (MARBURG_EPSG_4326.x, HAMBURG_EPSG_4326.y).into(),
             )
             .unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
         let ctx = MockQueryContext::new(ChunkByteSize::MAX);
 
         let query = query_processor.query(query_rectangle, &ctx).await.unwrap();
@@ -744,15 +759,15 @@ mod tests {
 
         let query_processor = query_processor.multi_line_string().unwrap();
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new(
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new(
                 (COLOGNE_EPSG_4326.x, MARBURG_EPSG_4326.y).into(),
                 (MARBURG_EPSG_4326.x, HAMBURG_EPSG_4326.y).into(),
             )
             .unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
         let ctx = MockQueryContext::new(ChunkByteSize::MAX);
 
         let query = query_processor.query(query_rectangle, &ctx).await.unwrap();
@@ -825,15 +840,15 @@ mod tests {
 
         let query_processor = query_processor.multi_polygon().unwrap();
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new(
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new(
                 (COLOGNE_EPSG_4326.x, MARBURG_EPSG_4326.y).into(),
                 (MARBURG_EPSG_4326.x, HAMBURG_EPSG_4326.y).into(),
             )
             .unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
         let ctx = MockQueryContext::new(ChunkByteSize::MAX);
 
         let query = query_processor.query(query_rectangle, &ctx).await.unwrap();
@@ -941,11 +956,12 @@ mod tests {
             .get_u8()
             .unwrap();
 
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 1.).into(), (3., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 10),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 1.).into(), (3., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 10),
+        );
 
         let a = qp.raster_query(query_rect, &query_ctx).await?;
 
@@ -963,8 +979,9 @@ mod tests {
         let mut exe_ctx = MockExecutionContext::test_default();
         let query_ctx = MockQueryContext::test_default();
         let id = add_ndvi_dataset(&mut exe_ctx);
+        let tiling_origin_coordinate = (0., 0.).into();
         exe_ctx.tiling_specification =
-            TilingSpecification::new((0.0, 0.0).into(), [450, 450].into());
+            TilingSpecification::new(tiling_origin_coordinate, [450, 450].into());
 
         let output_shape: GridShape2D = [900, 1800].into();
         let output_bounds =
@@ -1006,11 +1023,12 @@ mod tests {
 
         let qs = qp
             .raster_query(
-                RasterQueryRectangle {
-                    spatial_bounds: output_bounds,
-                    time_interval,
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    output_bounds,
                     spatial_resolution,
-                },
+                    tiling_origin_coordinate,
+                    time_interval,
+                ),
                 &query_ctx,
             )
             .await
@@ -1041,19 +1059,19 @@ mod tests {
 
     #[test]
     fn query_rewrite_4326_3857() {
-        let query = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new_unchecked((-180., -90.).into(), (180., 90.).into()),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let query = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new_unchecked((-180., -90.).into(), (180., 90.).into()),
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
 
         let expected = BoundingBox2D::new_unchecked(
             (-20_037_508.342_789_244, -20_048_966.104_014_594).into(),
             (20_037_508.342_789_244, 20_048_966.104_014_594).into(),
         );
 
-        let reprojected = reproject_query(
-            query,
+        let reprojected = reproject_spatial_query(
+            query.spatial_query(),
             SpatialReference::new(SpatialReferenceAuthority::Epsg, 3857),
             SpatialReference::epsg_4326(),
         )
@@ -1161,11 +1179,12 @@ mod tests {
 
         let qs = qp
             .raster_query(
-                QueryRectangle {
-                    spatial_bounds: output_bounds,
-                    time_interval,
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    output_bounds,
                     spatial_resolution,
-                },
+                    exe_ctx.tiling_specification.origin_coordinate,
+                    time_interval,
+                ),
                 &query_ctx,
             )
             .await
@@ -1296,11 +1315,12 @@ mod tests {
 
         let result = qp
             .raster_query(
-                QueryRectangle {
-                    spatial_bounds: output_bounds,
-                    time_interval,
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    output_bounds,
                     spatial_resolution,
-                },
+                    exe_ctx.tiling_specification.origin_coordinate,
+                    time_interval,
+                ),
                 &query_ctx,
             )
             .await
@@ -1366,11 +1386,11 @@ mod tests {
 
         let qs = qp
             .vector_query(
-                QueryRectangle {
+                VectorQueryRectangle::with_bounds_and_resolution(
                     spatial_bounds,
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::zero_point_one(),
-                },
+                    TimeInterval::default(),
+                    SpatialResolution::zero_point_one(),
+                ),
                 &query_ctx,
             )
             .await
@@ -1443,11 +1463,11 @@ mod tests {
 
         let qs = qp
             .vector_query(
-                QueryRectangle {
+                VectorQueryRectangle::with_bounds_and_resolution(
                     spatial_bounds,
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::zero_point_one(),
-                },
+                    TimeInterval::default(),
+                    SpatialResolution::zero_point_one(),
+                ),
                 &query_ctx,
             )
             .await
@@ -1521,11 +1541,11 @@ mod tests {
 
         let qs = qp
             .vector_query(
-                QueryRectangle {
+                VectorQueryRectangle::with_bounds_and_resolution(
                     spatial_bounds,
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::zero_point_one(),
-                },
+                    TimeInterval::default(),
+                    SpatialResolution::zero_point_one(),
+                ),
                 &query_ctx,
             )
             .await

--- a/operators/src/processing/temporal_raster_aggregation/subquery.rs
+++ b/operators/src/processing/temporal_raster_aggregation/subquery.rs
@@ -183,12 +183,15 @@ where
         query_rect: RasterQueryRectangle,
         start_time: TimeInstance,
     ) -> Result<Option<RasterQueryRectangle>> {
-        let snapped_start = self.step.snap_relative(self.step_reference, start_time)?;
-        Ok(Some(RasterQueryRectangle {
-            spatial_bounds: tile_info.spatial_partition(),
-            spatial_resolution: query_rect.spatial_resolution,
-            time_interval: TimeInterval::new(snapped_start, (snapped_start + self.step)?)?,
-        }))
+        let snapped_start_time = self.step.snap_relative(self.step_reference, start_time)?;
+        Ok(Some(
+            RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                tile_info.spatial_partition(),
+                query_rect.spatial_query().spatial_resolution(),
+                query_rect.spatial_query().origin_coordinate(),
+                TimeInterval::new(snapped_start_time, (snapped_start_time + self.step)?)?,
+            ),
+        ))
     }
 
     fn fold_method(&self) -> Self::FoldMethod {

--- a/operators/src/processing/temporal_raster_aggregation/temporal_aggregation_operator.rs
+++ b/operators/src/processing/temporal_raster_aggregation/temporal_aggregation_operator.rs
@@ -22,7 +22,9 @@ use crate::{
     util::Result,
 };
 use async_trait::async_trait;
-use geoengine_datatypes::primitives::{RasterQueryRectangle, SpatialPartition2D, TimeInstance};
+use geoengine_datatypes::primitives::{
+    RasterQueryRectangle, RasterSpatialQueryRectangle, TimeInstance,
+};
 use geoengine_datatypes::raster::{Pixel, RasterDataType, RasterTile2D};
 use geoengine_datatypes::{primitives::TimeStep, raster::TilingSpecification};
 use log::debug;
@@ -245,11 +247,11 @@ where
 #[async_trait]
 impl<Q, P> QueryProcessor for TemporalRasterAggregationProcessor<Q, P>
 where
-    Q: QueryProcessor<Output = RasterTile2D<P>, SpatialBounds = SpatialPartition2D>,
+    Q: QueryProcessor<Output = RasterTile2D<P>, SpatialQuery = RasterSpatialQueryRectangle>,
     P: Pixel,
 {
     type Output = RasterTile2D<P>;
-    type SpatialBounds = SpatialPartition2D;
+    type SpatialQuery = RasterSpatialQueryRectangle;
 
     #[allow(clippy::too_many_lines)]
     async fn _query<'a>(
@@ -403,7 +405,7 @@ where
 mod tests {
     use futures::stream::StreamExt;
     use geoengine_datatypes::{
-        primitives::{CacheHint, Measurement, SpatialResolution, TimeInterval},
+        primitives::{CacheHint, Measurement, SpatialPartition2D, SpatialResolution, TimeInterval},
         raster::{
             EmptyGrid, EmptyGrid2D, Grid2D, GridOrEmpty, MaskedGrid2D, RasterDataType,
             TileInformation, TilesEqualIgnoringCacheHint,
@@ -460,11 +462,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 40),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 40),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp = agg
@@ -578,11 +581,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 40),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 40),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp = agg
@@ -696,11 +700,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 40),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 40),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp = agg
@@ -814,11 +819,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 40),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 40),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp = agg
@@ -939,11 +945,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (2., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 20),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (2., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 20),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp = agg
@@ -1017,11 +1024,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 30),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 30),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp = agg
@@ -1115,11 +1123,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 30),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 30),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp = agg
@@ -1213,11 +1222,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 30),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 30),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp = agg
@@ -1311,11 +1321,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 30),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 30),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp = agg
@@ -1409,11 +1420,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 30),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 30),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp = agg
@@ -1507,11 +1519,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 30),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 30),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp = agg
@@ -1604,11 +1617,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 30),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 30),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let query_processor = operator
@@ -1719,11 +1733,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 30),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 30),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp = agg
@@ -1817,11 +1832,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 30),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 30),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp = agg
@@ -1925,11 +1941,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 30),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 30),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let query_processor = operator
@@ -2051,11 +2068,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 30),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 30),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let query_processor = operator
@@ -2166,11 +2184,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 30),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 30),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp = agg
@@ -2264,11 +2283,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(0, 30),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(0, 30),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp = agg
@@ -2362,11 +2382,12 @@ mod tests {
             (0., 0.).into(),
             [3, 2].into(),
         ));
-        let query_rect = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(5, 5),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+            SpatialResolution::one(),
+            exe_ctx.tiling_specification.origin_coordinate,
+            TimeInterval::new_unchecked(5, 5),
+        );
         let query_ctx = MockQueryContext::test_default();
 
         let qp = agg

--- a/operators/src/processing/time_projection/mod.rs
+++ b/operators/src/processing/time_projection/mod.rs
@@ -235,11 +235,10 @@ fn expand_query_rectangle(
     step_reference: TimeInstance,
     query: VectorQueryRectangle,
 ) -> Result<VectorQueryRectangle, TimeProjectionError> {
-    Ok(VectorQueryRectangle {
-        spatial_bounds: query.spatial_bounds,
-        time_interval: expand_time_interval(step, step_reference, query.time_interval)?,
-        spatial_resolution: query.spatial_resolution,
-    })
+    Ok(VectorQueryRectangle::new(
+        query.spatial_query,
+        expand_time_interval(step, step_reference, query.time_interval)?,
+    ))
 }
 
 fn expand_time_interval(
@@ -458,15 +457,15 @@ mod tests {
 
         let mut stream = query_processor
             .vector_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (2., 2.).into()).unwrap(),
-                    time_interval: TimeInterval::new(
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (2., 2.).into()).unwrap(),
+                    TimeInterval::new(
                         DateTime::new_utc(2010, 4, 3, 0, 0, 0),
                         DateTime::new_utc(2010, 5, 14, 0, 0, 0),
                     )
                     .unwrap(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                    SpatialResolution::one(),
+                ),
                 &query_context,
             )
             .await
@@ -562,15 +561,15 @@ mod tests {
 
         let mut stream = query_processor
             .vector_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (2., 2.).into()).unwrap(),
-                    time_interval: TimeInterval::new(
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (2., 2.).into()).unwrap(),
+                    TimeInterval::new(
                         DateTime::new_utc(2010, 4, 3, 0, 0, 0),
                         DateTime::new_utc(2010, 5, 14, 0, 0, 0),
                     )
                     .unwrap(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                    SpatialResolution::one(),
+                ),
                 &query_context,
             )
             .await

--- a/operators/src/processing/time_shift.rs
+++ b/operators/src/processing/time_shift.rs
@@ -422,11 +422,7 @@ where
     ) -> Result<BoxStream<'a, Result<Self::VectorType>>> {
         let (time_interval, state) = self.shift.shift(query.time_interval)?;
 
-        let query = VectorQueryRectangle {
-            spatial_bounds: query.spatial_bounds,
-            time_interval,
-            spatial_resolution: query.spatial_resolution,
-        };
+        let query = VectorQueryRectangle::new(query.spatial_query, time_interval);
         let stream = self.processor.vector_query(query, ctx).await?;
 
         let stream = stream.then(move |collection| async move {
@@ -467,11 +463,7 @@ where
         ctx: &'a dyn QueryContext,
     ) -> Result<BoxStream<'a, Result<RasterTile2D<Self::RasterType>>>> {
         let (time_interval, state) = self.shift.shift(query.time_interval)?;
-        let query = RasterQueryRectangle {
-            spatial_bounds: query.spatial_bounds,
-            time_interval,
-            spatial_resolution: query.spatial_resolution,
-        };
+        let query = RasterQueryRectangle::new(query.spatial_query, time_interval);
         let stream = self.processor.raster_query(query, ctx).await?;
 
         let stream = stream.map(move |raster| {
@@ -660,15 +652,15 @@ mod tests {
 
         let mut stream = query_processor
             .vector_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (2., 2.).into()).unwrap(),
-                    time_interval: TimeInterval::new(
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (2., 2.).into()).unwrap(),
+                    TimeInterval::new(
                         DateTime::new_utc(2009, 1, 1, 0, 0, 0),
                         DateTime::new_utc(2012, 1, 1, 0, 0, 0),
                     )
                     .unwrap(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                    SpatialResolution::one(),
+                ),
                 &query_context,
             )
             .await
@@ -748,15 +740,15 @@ mod tests {
 
         let mut stream = query_processor
             .vector_query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (2., 2.).into()).unwrap(),
-                    time_interval: TimeInterval::new(
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (2., 2.).into()).unwrap(),
+                    TimeInterval::new(
                         DateTime::new_utc(2010, 1, 1, 0, 0, 0),
                         DateTime::new_utc(2011, 1, 1, 0, 0, 0),
                     )
                     .unwrap(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                    SpatialResolution::one(),
+                ),
                 &query_context,
             )
             .await
@@ -919,18 +911,16 @@ mod tests {
 
         let mut stream = query_processor
             .raster_query(
-                RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 3.).into(),
-                        (4., 0.).into(),
-                    ),
-                    time_interval: TimeInterval::new(
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+                    SpatialResolution::one(),
+                    execution_context.tiling_specification.origin_coordinate,
+                    TimeInterval::new(
                         DateTime::new_utc(2010, 1, 1, 0, 0, 0),
                         DateTime::new_utc(2011, 1, 1, 0, 0, 0),
                     )
                     .unwrap(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                ),
                 &query_context,
             )
             .await
@@ -1085,18 +1075,16 @@ mod tests {
 
         let mut stream = query_processor
             .raster_query(
-                RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 3.).into(),
-                        (4., 0.).into(),
-                    ),
-                    time_interval: TimeInterval::new(
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    SpatialPartition2D::new_unchecked((0., 3.).into(), (4., 0.).into()),
+                    SpatialResolution::one(),
+                    execution_context.tiling_specification.origin_coordinate,
+                    TimeInterval::new(
                         DateTime::new_utc(2010, 1, 1, 0, 0, 0),
                         DateTime::new_utc(2011, 1, 1, 0, 0, 0),
                     )
                     .unwrap(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                ),
                 &query_context,
             )
             .await
@@ -1170,17 +1158,12 @@ mod tests {
 
         let mut stream = query_processor
             .raster_query(
-                RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (-180., 90.).into(),
-                        (180., -90.).into(),
-                    ),
-                    time_interval: TimeInterval::new_instant(DateTime::new_utc(
-                        2014, 3, 1, 0, 0, 0,
-                    ))
-                    .unwrap(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    SpatialPartition2D::new_unchecked((-180., 90.).into(), (180., -90.).into()),
+                    SpatialResolution::one(),
+                    execution_context.tiling_specification.origin_coordinate,
+                    TimeInterval::new_instant(DateTime::new_utc(2014, 3, 1, 0, 0, 0)).unwrap(),
+                ),
                 &query_context,
             )
             .await
@@ -1236,17 +1219,12 @@ mod tests {
 
         let mut stream = query_processor
             .raster_query(
-                RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (-180., 90.).into(),
-                        (180., -90.).into(),
-                    ),
-                    time_interval: TimeInterval::new_instant(DateTime::new_utc(
-                        2014, 3, 1, 0, 0, 0,
-                    ))
-                    .unwrap(),
-                    spatial_resolution: SpatialResolution::one(),
-                },
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    SpatialPartition2D::new_unchecked((-180., 90.).into(), (180., -90.).into()),
+                    SpatialResolution::one(),
+                    execution_context.tiling_specification.origin_coordinate,
+                    TimeInterval::new_instant(DateTime::new_utc(2014, 3, 1, 0, 0, 0)).unwrap(),
+                ),
                 &query_context,
             )
             .await

--- a/operators/src/processing/vector_join/equi_data_join.rs
+++ b/operators/src/processing/vector_join/equi_data_join.rs
@@ -11,7 +11,7 @@ use geoengine_datatypes::collections::{
     GeometryRandomAccess,
 };
 use geoengine_datatypes::primitives::{
-    BoundingBox2D, FeatureDataRef, Geometry, TimeInterval, VectorQueryRectangle,
+    FeatureDataRef, Geometry, TimeInterval, VectorQueryRectangle, VectorSpatialQueryRectangle,
 };
 use geoengine_datatypes::util::arrow::ArrowTyped;
 
@@ -352,7 +352,7 @@ where
     FeatureCollectionRowBuilder<G>: GeoFeatureCollectionRowBuilder<G>,
 {
     type Output = FeatureCollection<G>;
-    type SpatialBounds = BoundingBox2D;
+    type SpatialQuery = VectorSpatialQueryRectangle;
 
     async fn _query<'a>(
         &'a self,
@@ -436,15 +436,11 @@ mod tests {
         let left_processor = left.query_processor().unwrap().multi_point().unwrap();
         let right_processor = right.query_processor().unwrap().data().unwrap();
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new(
-                (f64::MIN, f64::MIN).into(),
-                (f64::MAX, f64::MAX).into(),
-            )
-            .unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((f64::MIN, f64::MIN).into(), (f64::MAX, f64::MAX).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
 
         let ctx = MockQueryContext::new(ChunkByteSize::MAX);
 

--- a/operators/src/source/gdal_source/loading_info.rs
+++ b/operators/src/source/gdal_source/loading_info.rs
@@ -501,8 +501,8 @@ mod tests {
     use geoengine_datatypes::{
         hashmap,
         primitives::{
-            DateTime, DateTimeParseFormat, Measurement, SpatialPartition2D, SpatialResolution,
-            TimeGranularity,
+            Coordinate2D, DateTime, DateTimeParseFormat, Measurement, SpatialPartition2D,
+            SpatialResolution, TimeGranularity,
         },
         raster::RasterDataType,
         spatial_reference::SpatialReference,
@@ -580,14 +580,11 @@ mod tests {
 
         assert_eq!(
             meta_data
-                .loading_info(RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 1.).into(),
-                        (1., 0.).into()
-                    ),
-                    time_interval: TimeInterval::new_unchecked(0, 30),
-                    spatial_resolution: SpatialResolution::one(),
-                })
+                .loading_info(RasterQueryRectangle::with_partition_and_resolution(
+                    SpatialPartition2D::new_unchecked((0., 1.).into(), (1., 0.).into()),
+                    SpatialResolution::one(),
+                    TimeInterval::new_unchecked(0, 30),
+                ))
                 .await
                 .unwrap()
                 .info
@@ -622,14 +619,11 @@ mod tests {
 
         assert_eq!(
             meta_data
-                .loading_info(RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 1.).into(),
-                        (1., 0.).into()
-                    ),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::one(),
-                })
+                .loading_info(RasterQueryRectangle::with_partition_and_resolution(
+                    SpatialPartition2D::new_unchecked((0., 1.).into(), (1., 0.).into()),
+                    SpatialResolution::one(),
+                    TimeInterval::default(),
+                ))
                 .await
                 .unwrap()
                 .info
@@ -666,14 +660,11 @@ mod tests {
 
         assert_eq!(
             meta_data
-                .loading_info(RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 1.).into(),
-                        (1., 0.).into()
-                    ),
-                    time_interval: TimeInterval::new_unchecked(-10, -5),
-                    spatial_resolution: SpatialResolution::one(),
-                })
+                .loading_info(RasterQueryRectangle::with_partition_and_resolution(
+                    SpatialPartition2D::new_unchecked((0., 1.).into(), (1., 0.).into()),
+                    SpatialResolution::one(),
+                    TimeInterval::new_unchecked(-10, -5),
+                ))
                 .await
                 .unwrap()
                 .info
@@ -695,14 +686,11 @@ mod tests {
 
         assert_eq!(
             meta_data
-                .loading_info(RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 1.).into(),
-                        (1., 0.).into()
-                    ),
-                    time_interval: TimeInterval::new_unchecked(50, 55),
-                    spatial_resolution: SpatialResolution::one(),
-                })
+                .loading_info(RasterQueryRectangle::with_partition_and_resolution(
+                    SpatialPartition2D::new_unchecked((0., 1.).into(), (1., 0.).into()),
+                    SpatialResolution::one(),
+                    TimeInterval::new_unchecked(50, 55),
+                ))
                 .await
                 .unwrap()
                 .info
@@ -724,14 +712,11 @@ mod tests {
 
         assert_eq!(
             meta_data
-                .loading_info(RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 1.).into(),
-                        (1., 0.).into()
-                    ),
-                    time_interval: TimeInterval::new_unchecked(0, 22),
-                    spatial_resolution: SpatialResolution::one(),
-                })
+                .loading_info(RasterQueryRectangle::with_partition_and_resolution(
+                    SpatialPartition2D::new_unchecked((0., 1.).into(), (1., 0.).into()),
+                    SpatialResolution::one(),
+                    TimeInterval::new_unchecked(0, 22),
+                ))
                 .await
                 .unwrap()
                 .info
@@ -762,14 +747,11 @@ mod tests {
 
         assert_eq!(
             meta_data
-                .loading_info(RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 1.).into(),
-                        (1., 0.).into()
-                    ),
-                    time_interval: TimeInterval::new_unchecked(0, 20),
-                    spatial_resolution: SpatialResolution::one(),
-                })
+                .loading_info(RasterQueryRectangle::with_partition_and_resolution(
+                    SpatialPartition2D::new_unchecked((0., 1.).into(), (1., 0.).into()),
+                    SpatialResolution::one(),
+                    TimeInterval::new_unchecked(0, 20),
+                ))
                 .await
                 .unwrap()
                 .info
@@ -880,14 +862,11 @@ mod tests {
 
         assert_eq!(
             meta_data
-                .loading_info(RasterQueryRectangle {
-                    spatial_bounds: SpatialPartition2D::new_unchecked(
-                        (0., 1.).into(),
-                        (1., 0.).into()
-                    ),
-                    time_interval: TimeInterval::new_unchecked(0, 3),
-                    spatial_resolution: SpatialResolution::one(),
-                })
+                .loading_info(RasterQueryRectangle::with_partition_and_resolution(
+                    SpatialPartition2D::new_unchecked((0., 1.).into(), (1., 0.).into()),
+                    SpatialResolution::one(),
+                    TimeInterval::new_unchecked(0, 3),
+                ))
                 .await
                 .unwrap()
                 .info
@@ -947,11 +926,12 @@ mod tests {
             cache_ttl: CacheTtlSeconds::default(),
         };
 
-        let query = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 128.).into(), (128., 0.).into()),
-            time_interval: TimeInterval::new(time_start, time_end).unwrap(),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 128.).into(), (128., 0.).into()),
+            SpatialResolution::one(),
+            Coordinate2D::new(0., 0.), // FIXME: is this correct here?
+            TimeInterval::new(time_start, time_end).unwrap(),
+        );
 
         let loading_info = metadata.loading_info(query).await.unwrap();
         let mut iter = loading_info.info;
@@ -1014,11 +994,11 @@ mod tests {
             cache_ttl: CacheTtlSeconds::default(),
         };
 
-        let query = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 128.).into(), (128., 0.).into()),
-            time_interval: TimeInterval::new(time_start, time_end).unwrap(),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        let query = RasterQueryRectangle::with_partition_and_resolution(
+            SpatialPartition2D::new_unchecked((0., 128.).into(), (128., 0.).into()),
+            SpatialResolution::one(),
+            TimeInterval::new(time_start, time_end).unwrap(),
+        );
 
         let loading_info = metadata.loading_info(query).await.unwrap();
         let mut iter = loading_info.info;
@@ -1081,14 +1061,15 @@ mod tests {
             cache_ttl: CacheTtlSeconds::default(),
         };
 
-        let query = RasterQueryRectangle {
-            spatial_bounds: SpatialPartition2D::new_unchecked((0., 128.).into(), (128., 0.).into()),
-            time_interval: TimeInterval::new_unchecked(
+        let query = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+            SpatialPartition2D::new_unchecked((0., 128.).into(), (128., 0.).into()),
+            SpatialResolution::one(),
+            Coordinate2D::new(0., 0.), // FIXME: is this correct here?
+            TimeInterval::new_unchecked(
                 TimeInstance::from(DateTime::new_utc(2009, 7, 1, 0, 0, 0)),
                 TimeInstance::from(DateTime::new_utc(2013, 3, 1, 0, 0, 0)),
             ),
-            spatial_resolution: SpatialResolution::one(),
-        };
+        );
 
         let loading_info = metadata.loading_info(query).await.unwrap();
         let mut iter = loading_info.info;

--- a/operators/src/source/gdal_source/mod.rs
+++ b/operators/src/source/gdal_source/mod.rs
@@ -30,7 +30,7 @@ use geoengine_datatypes::dataset::NamedData;
 use geoengine_datatypes::primitives::CacheHint;
 use geoengine_datatypes::primitives::{
     AxisAlignedRectangle, Coordinate2D, DateTimeParseFormat, RasterQueryRectangle,
-    SpatialPartition2D, SpatialPartitioned,
+    RasterSpatialQueryRectangle, SpatialPartition2D, SpatialPartitioned,
 };
 use geoengine_datatypes::raster::TileInformation;
 use geoengine_datatypes::raster::{
@@ -594,15 +594,17 @@ impl GdalRasterLoader {
         info: GdalLoadingInfoTemporalSlice,
         tiling_strategy: TilingStrategy,
     ) -> impl Stream<Item = impl Future<Output = Result<RasterTile2D<T>>>> {
-        stream::iter(tiling_strategy.tile_information_iterator(query.spatial_bounds)).map(
-            move |tile| {
-                GdalRasterLoader::load_tile_async(
-                    info.params.clone(),
-                    tile,
-                    info.time,
-                    info.cache_ttl.into(),
-                )
-            },
+        stream::iter(
+            tiling_strategy
+                .tile_information_iterator_from_grid_bounds(query.spatial_query.grid_bounds)
+                .map(move |tile| {
+                    GdalRasterLoader::load_tile_async(
+                        info.params.clone(),
+                        tile,
+                        info.time,
+                        info.cache_ttl.into(),
+                    )
+                }),
         )
     }
 
@@ -652,7 +654,7 @@ where
     P: Pixel + gdal::raster::GdalType + FromPrimitive,
 {
     type Output = RasterTile2D<P>;
-    type SpatialBounds = SpatialPartition2D;
+    type SpatialQuery = RasterSpatialQueryRectangle;
 
     async fn _query<'a>(
         &'a self,
@@ -672,7 +674,17 @@ where
             start.elapsed()
         );
 
-        let spatial_resolution = query.spatial_resolution;
+        let query_geo_transform = query.spatial_query().geo_transform;
+
+        assert_eq!(
+            query_geo_transform.origin_coordinate,
+            self.tiling_specification.origin_coordinate
+        );
+
+        let tiling_strategy = TilingStrategy::new(
+            self.tiling_specification.tile_size_in_pixels,
+            query_geo_transform,
+        );
 
         // A `GeoTransform` maps pixel space to world space.
         // Usually a SRS has axis directions pointing "up" (y-axis) and "up" (y-axis).
@@ -680,25 +692,21 @@ where
         // However, there are spatial reference systems where the y-axis points downwards.
         // The standard "pixel-space" starts at the top-left corner of a `GeoTransform` and points down-right.
         // Therefore, the pixel size on the x-axis is always increasing
-        let pixel_size_x = spatial_resolution.x;
+        let pixel_size_x = query_geo_transform.x_pixel_size();
         debug_assert!(pixel_size_x.is_sign_positive());
         // and the y-axis should only be positive if the y-axis of the spatial reference system also "points down".
         // NOTE: at the moment we do not allow "down pointing" y-axis.
-        let pixel_size_y = spatial_resolution.y * -1.0;
+        let pixel_size_y = query_geo_transform.y_pixel_size();
         debug_assert!(pixel_size_y.is_sign_negative());
-
-        let tiling_strategy = self
-            .tiling_specification
-            .strategy(pixel_size_x, pixel_size_y);
 
         let result_descriptor = self.meta_data.result_descriptor().await?;
 
         let mut empty = false;
         debug!("result descr bbox: {:?}", result_descriptor.bbox);
-        debug!("query bbox: {:?}", query.spatial_bounds);
+        debug!("query bbox: {:?}", query.spatial_query);
 
         if let Some(data_spatial_bounds) = result_descriptor.bbox {
-            if !data_spatial_bounds.intersects(&query.spatial_bounds) {
+            if !data_spatial_bounds.intersects(&query.spatial_query().spatial_partition()) {
                 debug!("query does not intersect spatial data bounds");
                 empty = true;
             }
@@ -731,7 +739,7 @@ where
         // use SparseTilesFillAdapter to fill all the gaps
         let filled_stream = SparseTilesFillAdapter::new(
             source_stream,
-            tiling_strategy.tile_grid_box(query.spatial_partition()),
+            tiling_strategy.tile_grid_box(query.spatial_query().spatial_partition()),
             tiling_strategy.geo_transform,
             tiling_strategy.tile_size_in_pixels,
             FillerTileCacheExpirationStrategy::DerivedFromSurroundingTiles,
@@ -1212,11 +1220,12 @@ mod tests {
             .get_u8()
             .unwrap()
             .raster_query(
-                RasterQueryRectangle {
-                    spatial_bounds: output_bounds,
-                    time_interval,
+                RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                    output_bounds,
                     spatial_resolution,
-                },
+                    exe_ctx.tiling_specification.origin_coordinate,
+                    time_interval,
+                ),
                 query_ctx,
             )
             .await
@@ -1365,7 +1374,7 @@ mod tests {
             dataset_y_pixel_size,
         );
 
-        let partition = SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into()).unwrap();
+        let grid_bounds = GridBoundingBox2D::new([-900, -1800], [899, 1799]).unwrap();
 
         let origin_split_tileing_strategy = TilingStrategy {
             tile_size_in_pixels: tile_size_in_pixels.into(),
@@ -1373,7 +1382,7 @@ mod tests {
         };
 
         let vres: Vec<GridIdx2D> = origin_split_tileing_strategy
-            .tile_idx_iterator(partition)
+            .tile_idx_iterator_from_grid_bounds(grid_bounds)
             .collect();
         assert_eq!(vres.len(), 4 * 6);
         assert_eq!(vres[0], [-2, -3].into());
@@ -1395,7 +1404,7 @@ mod tests {
             dataset_y_pixel_size,
         );
 
-        let partition = SpatialPartition2D::new((-180., 90.).into(), (180., -90.).into()).unwrap();
+        let grid_bounds = GridBoundingBox2D::new([-900, -1800], [899, 1799]).unwrap();
 
         let origin_split_tileing_strategy = TilingStrategy {
             tile_size_in_pixels: tile_size_in_pixels.into(),
@@ -1403,7 +1412,7 @@ mod tests {
         };
 
         let vres: Vec<TileInformation> = origin_split_tileing_strategy
-            .tile_information_iterator(partition)
+            .tile_information_iterator_from_grid_bounds(grid_bounds)
             .collect();
         assert_eq!(vres.len(), 4 * 6);
         assert_eq!(

--- a/operators/src/source/ogr_source/dataset_iterator.rs
+++ b/operators/src/source/ogr_source/dataset_iterator.rs
@@ -8,7 +8,7 @@ use crate::util::Result;
 use gdal::vector::sql::Dialect;
 use gdal::vector::{Feature, LayerAccess};
 use gdal::{Dataset, DatasetOptions, GdalOpenFlags};
-use geoengine_datatypes::primitives::VectorQueryRectangle;
+use geoengine_datatypes::primitives::{SpatialBounded, VectorQueryRectangle};
 use log::debug;
 use ouroboros::self_referencing;
 use std::cell::Cell;
@@ -137,10 +137,10 @@ impl OgrDatasetIterator {
         if use_ogr_spatial_filter {
             debug!(
                 "using spatial filter {:?} for layer {:?}",
-                query_rectangle.spatial_bounds, &dataset_information.layer_name
+                query_rectangle.spatial_query, &dataset_information.layer_name
             );
             // NOTE: the OGR-filter may be inaccurately allowing more features that should be returned in a "strict" fashion.
-            features_provider.set_spatial_filter(&query_rectangle.spatial_bounds);
+            features_provider.set_spatial_filter(&query_rectangle.spatial_query().spatial_bounds());
         }
 
         let filter_string = if dataset.driver().short_name() == "CSV" {

--- a/operators/src/source/ogr_source/mod.rs
+++ b/operators/src/source/ogr_source/mod.rs
@@ -33,7 +33,8 @@ use geoengine_datatypes::collections::{
 use geoengine_datatypes::primitives::{
     AxisAlignedRectangle, BoundingBox2D, Coordinate2D, DateTime, DateTimeParseFormat,
     FeatureDataType, FeatureDataValue, Geometry, MultiLineString, MultiPoint, MultiPolygon,
-    NoGeometry, TimeInstance, TimeInterval, TimeStep, TypedGeometry, VectorQueryRectangle,
+    NoGeometry, SpatialBounded, TimeInstance, TimeInterval, TimeStep, TypedGeometry,
+    VectorQueryRectangle, VectorSpatialQueryRectangle,
 };
 use geoengine_datatypes::util::arrow::ArrowTyped;
 
@@ -515,7 +516,7 @@ where
     FeatureCollectionRowBuilder<G>: FeatureCollectionBuilderGeometryHandler<G>,
 {
     type Output = FeatureCollection<G>;
-    type SpatialBounds = BoundingBox2D;
+    type SpatialQuery = VectorSpatialQueryRectangle;
 
     async fn _query<'a>(
         &'a self,
@@ -1216,7 +1217,7 @@ where
 
         // filter out geometries that are not contained in the query's bounding box
         if !was_spatial_filtered_by_ogr
-            && !geometry.intersects_bbox(&query_rectangle.spatial_bounds)
+            && !geometry.intersects_bbox(&query_rectangle.spatial_query().spatial_bounds())
         {
             return Ok(());
         }
@@ -1655,11 +1656,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -1707,11 +1708,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (1., 1.).into()).unwrap(),
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.).unwrap(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (1., 1.).into()).unwrap(),
+                    Default::default(),
+                    SpatialResolution::new(1., 1.).unwrap(),
+                ),
                 &context,
             )
             .await;
@@ -1752,11 +1753,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (5., 5.).into()).unwrap(),
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.).unwrap(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (5., 5.).into()).unwrap(),
+                    Default::default(),
+                    SpatialResolution::new(1., 1.).unwrap(),
+                ),
                 &context,
             )
             .await
@@ -1802,11 +1803,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (5., 5.).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (5., 5.).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -1887,11 +1888,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((1.85, 50.88).into(), (4.82, 52.95).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((1.85, 50.88).into(), (4.82, 52.95).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -1986,11 +1987,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((1.85, 50.88).into(), (4.82, 52.95).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((1.85, 50.88).into(), (4.82, 52.95).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -2088,11 +2089,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((1.85, 50.88).into(), (4.82, 52.95).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((1.85, 50.88).into(), (4.82, 52.95).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -2241,11 +2242,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((1.85, 50.88).into(), (4.82, 52.95).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((1.85, 50.88).into(), (4.82, 52.95).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -2415,14 +2416,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new(
-                        (-180.0, -90.0).into(),
-                        (180.0, 90.0).into(),
-                    )?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((-180.0, -90.0).into(), (180.0, 90.0).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -3601,11 +3599,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -3720,11 +3718,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (1., 2.).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (1., 2.).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -3929,11 +3927,11 @@ mod tests {
         let context1 = MockQueryContext::new(ChunkByteSize::MIN);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: query_bbox,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    query_bbox,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context1,
             )
             .await
@@ -3963,11 +3961,11 @@ mod tests {
         let context = MockQueryContext::new((1_650).into());
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: query_bbox,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    query_bbox,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -4080,11 +4078,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MIN);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: query_bbox,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.).unwrap(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    query_bbox,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.).unwrap(),
+                ),
                 &context,
             )
             .await
@@ -4169,11 +4167,11 @@ mod tests {
         let context = MockQueryContext::new((1024 * 1024).into());
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: query_bbox,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.).unwrap(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    query_bbox,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.).unwrap(),
+                ),
                 &context,
             )
             .await
@@ -4289,11 +4287,11 @@ mod tests {
         let context = MockQueryContext::new((1024 * 1024).into());
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: query_bbox,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.).unwrap(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    query_bbox,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.).unwrap(),
+                ),
                 &context,
             )
             .await
@@ -4416,11 +4414,11 @@ mod tests {
         let context = MockQueryContext::new((1024 * 1024).into());
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: query_bbox,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.).unwrap(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    query_bbox,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.).unwrap(),
+                ),
                 &context,
             )
             .await
@@ -4541,11 +4539,11 @@ mod tests {
         let context = MockQueryContext::new((1024 * 1024).into());
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: query_bbox,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.).unwrap(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    query_bbox,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.).unwrap(),
+                ),
                 &context,
             )
             .await
@@ -4666,11 +4664,11 @@ mod tests {
         let context = MockQueryContext::new((1024 * 1024).into());
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: query_bbox,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.).unwrap(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    query_bbox,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.).unwrap(),
+                ),
                 &context,
             )
             .await
@@ -4787,11 +4785,11 @@ mod tests {
         let context = MockQueryContext::new((1024 * 1024).into());
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: query_bbox,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.).unwrap(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    query_bbox,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.).unwrap(),
+                ),
                 &context,
             )
             .await
@@ -4921,11 +4919,11 @@ mod tests {
         let context = MockQueryContext::new((1024 * 1024).into());
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: query_bbox,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.).unwrap(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    query_bbox,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.).unwrap(),
+                ),
                 &context,
             )
             .await
@@ -5041,11 +5039,11 @@ mod tests {
         let context = MockQueryContext::new((1024 * 1024).into());
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: query_bbox,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.).unwrap(),
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    query_bbox,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.).unwrap(),
+                ),
                 &context,
             )
             .await
@@ -5152,11 +5150,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -5278,11 +5276,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -5393,11 +5391,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -5508,11 +5506,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -5627,11 +5625,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -5745,11 +5743,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -5878,11 +5876,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -5993,11 +5991,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -6100,11 +6098,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -6193,11 +6191,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -6283,11 +6281,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -6373,11 +6371,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await
@@ -6463,11 +6461,11 @@ mod tests {
         let context = MockQueryContext::new(ChunkByteSize::MAX);
         let query = query_processor
             .query(
-                VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
-                    time_interval: Default::default(),
-                    spatial_resolution: SpatialResolution::new(1., 1.)?,
-                },
+                VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new((0., 0.).into(), (1., 1.).into())?,
+                    Default::default(),
+                    SpatialResolution::new(1., 1.)?,
+                ),
                 &context,
             )
             .await

--- a/operators/src/util/raster_stream_to_png.rs
+++ b/operators/src/util/raster_stream_to_png.rs
@@ -1,7 +1,9 @@
 use futures::{future::BoxFuture, StreamExt};
 use geoengine_datatypes::{
     operations::image::{Colorizer, DefaultColors, RgbaColor, ToPng},
-    primitives::{AxisAlignedRectangle, CacheHint, RasterQueryRectangle, TimeInterval},
+    primitives::{
+        AxisAlignedRectangle, CacheHint, RasterQueryRectangle, SpatialPartitioned, TimeInterval,
+    },
     raster::{Blit, EmptyGrid2D, GeoTransform, GridOrEmpty, Pixel, RasterTile2D},
 };
 use num_traits::AsPrimitive;
@@ -34,20 +36,19 @@ where
 
     let tile_stream = processor.query(query_rect, &query_ctx).await?;
 
-    let x_query_resolution = query_rect.spatial_bounds.size_x() / f64::from(width);
-    let y_query_resolution = query_rect.spatial_bounds.size_y() / f64::from(height);
-
     // build png
     let dim = [height as usize, width as usize];
-    let query_geo_transform = GeoTransform::new(
-        query_rect.spatial_bounds.upper_left(),
-        x_query_resolution,
-        -y_query_resolution, // TODO: negative, s.t. geo transform fits...
+    let query_geo_transform = query_rect.spatial_query().geo_transform;
+
+    let output_geo_transform = GeoTransform::new(
+        query_rect.spatial_query().spatial_partition().upper_left(),
+        query_geo_transform.x_pixel_size(),
+        query_geo_transform.y_pixel_size(),
     );
 
     let output_tile = Ok(RasterTile2D::new_without_offset(
         time.unwrap_or_default(),
-        query_geo_transform,
+        output_geo_transform,
         GridOrEmpty::from(EmptyGrid2D::new(dim.into())),
         CacheHint::max_duration(),
     ));
@@ -137,12 +138,12 @@ mod tests {
 
         let (image_bytes, _) = raster_stream_to_png_bytes(
             gdal_source.boxed(),
-            RasterQueryRectangle {
-                spatial_bounds: query_partition,
-                time_interval: TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000)
-                    .unwrap(),
-                spatial_resolution: SpatialResolution::zero_point_one(),
-            },
+            RasterQueryRectangle::with_partition_and_resolution_and_origin(
+                query_partition,
+                SpatialResolution::zero_point_one(),
+                Coordinate2D::new(0., 0.), // FIXME: check if this is correct here.
+                TimeInterval::new(1_388_534_400_000, 1_388_534_400_000 + 1000).unwrap(),
+            ),
             ctx,
             600,
             600,

--- a/services/src/api/model/operators.rs
+++ b/services/src/api/model/operators.rs
@@ -298,9 +298,7 @@ impl
         geoengine_operators::engine::StaticMetaData<
             geoengine_operators::mock::MockDatasetDataSourceLoadingInfo,
             geoengine_operators::engine::VectorResultDescriptor,
-            geoengine_datatypes::primitives::QueryRectangle<
-                geoengine_datatypes::primitives::BoundingBox2D,
-            >,
+            geoengine_datatypes::primitives::VectorQueryRectangle,
         >,
     >
     for StaticMetaData<
@@ -313,9 +311,7 @@ impl
         value: geoengine_operators::engine::StaticMetaData<
             geoengine_operators::mock::MockDatasetDataSourceLoadingInfo,
             geoengine_operators::engine::VectorResultDescriptor,
-            geoengine_datatypes::primitives::QueryRectangle<
-                geoengine_datatypes::primitives::BoundingBox2D,
-            >,
+            geoengine_datatypes::primitives::VectorQueryRectangle,
         >,
     ) -> Self {
         Self {
@@ -331,9 +327,7 @@ impl
         geoengine_operators::engine::StaticMetaData<
             geoengine_operators::source::OgrSourceDataset,
             geoengine_operators::engine::VectorResultDescriptor,
-            geoengine_datatypes::primitives::QueryRectangle<
-                geoengine_datatypes::primitives::BoundingBox2D,
-            >,
+            geoengine_datatypes::primitives::VectorQueryRectangle,
         >,
     > for StaticMetaData<OgrSourceDataset, VectorResultDescriptor, QueryRectangle<BoundingBox2D>>
 {
@@ -341,9 +335,7 @@ impl
         value: geoengine_operators::engine::StaticMetaData<
             geoengine_operators::source::OgrSourceDataset,
             geoengine_operators::engine::VectorResultDescriptor,
-            geoengine_datatypes::primitives::QueryRectangle<
-                geoengine_datatypes::primitives::BoundingBox2D,
-            >,
+            geoengine_datatypes::primitives::VectorQueryRectangle,
         >,
     ) -> Self {
         Self {
@@ -383,9 +375,7 @@ impl From<MockMetaData>
     for geoengine_operators::engine::StaticMetaData<
         geoengine_operators::mock::MockDatasetDataSourceLoadingInfo,
         geoengine_operators::engine::VectorResultDescriptor,
-        geoengine_datatypes::primitives::QueryRectangle<
-            geoengine_datatypes::primitives::BoundingBox2D,
-        >,
+        geoengine_datatypes::primitives::VectorQueryRectangle,
     >
 {
     fn from(value: MockMetaData) -> Self {
@@ -401,9 +391,7 @@ impl From<OgrMetaData>
     for geoengine_operators::engine::StaticMetaData<
         geoengine_operators::source::OgrSourceDataset,
         geoengine_operators::engine::VectorResultDescriptor,
-        geoengine_datatypes::primitives::QueryRectangle<
-            geoengine_datatypes::primitives::BoundingBox2D,
-        >,
+        geoengine_datatypes::primitives::VectorQueryRectangle,
     >
 {
     fn from(value: OgrMetaData) -> Self {

--- a/services/src/contexts/postgres.rs
+++ b/services/src/contexts/postgres.rs
@@ -931,14 +931,11 @@ mod tests {
 
             assert_eq!(
                 meta_data
-                    .loading_info(VectorQueryRectangle {
-                        spatial_bounds: BoundingBox2D::new_unchecked(
-                            (-180., -90.).into(),
-                            (180., 90.).into()
-                        ),
-                        time_interval: TimeInterval::default(),
-                        spatial_resolution: SpatialResolution::zero_point_one(),
-                    })
+                    .loading_info(VectorQueryRectangle::with_bounds_and_resolution(
+                        BoundingBox2D::new_unchecked((-180., -90.).into(), (180., 90.).into()),
+                        TimeInterval::default(),
+                        SpatialResolution::zero_point_one(),
+                    ))
                     .await
                     .unwrap(),
                 loading_info

--- a/services/src/datasets/external/aruna/mod.rs
+++ b/services/src/datasets/external/aruna/mod.rs
@@ -1812,11 +1812,11 @@ mod tests {
 
         let ctx = MockQueryContext::test_default();
 
-        let qr = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let qr = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
 
         let result: Vec<MultiPointCollection> = proc
             .query(qr, &ctx)

--- a/services/src/datasets/external/gbif.rs
+++ b/services/src/datasets/external/gbif.rs
@@ -1634,14 +1634,11 @@ mod tests {
                 }
 
                 let mut loading_info = meta
-                    .loading_info(VectorQueryRectangle {
-                        spatial_bounds: BoundingBox2D::new_unchecked(
-                            (-180., -90.).into(),
-                            (180., 90.).into(),
-                        ),
-                        time_interval: TimeInterval::default(),
-                        spatial_resolution: SpatialResolution::zero_point_one(),
-                    })
+                    .loading_info(VectorQueryRectangle::with_bounds_and_resolution(
+                        BoundingBox2D::new_unchecked((-180., -90.).into(), (180., 90.).into()),
+                        TimeInterval::default(),
+                        SpatialResolution::zero_point_one(),
+                    ))
                     .await
                     .map_err(|e| e.to_string())?;
 
@@ -1773,15 +1770,15 @@ mod tests {
                 let processor: OgrSourceProcessor<MultiPoint> =
                     OgrSourceProcessor::new(meta, vec![]);
 
-                let query_rectangle = VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new(
+                let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new(
                         (-61.065_22, 14.775_33).into(),
                         (-61.065_22, 14.775_33).into(),
                     )
                     .unwrap(),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::zero_point_one(),
-                };
+                    TimeInterval::default(),
+                    SpatialResolution::zero_point_one(),
+                );
                 let ctx = MockQueryContext::test_default();
 
                 let result: Vec<_> = processor

--- a/services/src/datasets/external/gfbio_abcd.rs
+++ b/services/src/datasets/external/gfbio_abcd.rs
@@ -677,14 +677,11 @@ mod tests {
             }
 
             let mut loading_info = meta
-                .loading_info(VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new_unchecked(
-                        (-180., -90.).into(),
-                        (180., 90.).into(),
-                    ),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::zero_point_one(),
-                })
+                .loading_info(VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new_unchecked((-180., -90.).into(), (180., 90.).into()),
+                    TimeInterval::default(),
+                    SpatialResolution::zero_point_one(),
+                ))
                 .await
                 .map_err(|e| e.to_string())?;
 
@@ -816,11 +813,11 @@ mod tests {
 
             let processor: OgrSourceProcessor<MultiPoint> = OgrSourceProcessor::new(meta, vec![]);
 
-            let query_rectangle = VectorQueryRectangle {
-                spatial_bounds: BoundingBox2D::new((0., -90.).into(), (180., 90.).into()).unwrap(),
-                time_interval: TimeInterval::default(),
-                spatial_resolution: SpatialResolution::zero_point_one(),
-            };
+            let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+                BoundingBox2D::new((0., -90.).into(), (180., 90.).into()).unwrap(),
+                TimeInterval::default(),
+                SpatialResolution::zero_point_one(),
+            );
             let ctx = MockQueryContext::test_default();
 
             let result: Vec<_> = processor

--- a/services/src/datasets/external/gfbio_collections.rs
+++ b/services/src/datasets/external/gfbio_collections.rs
@@ -1094,14 +1094,11 @@ mod tests {
             }
 
             let mut loading_info = meta
-                .loading_info(VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new_unchecked(
-                        (-180., -90.).into(),
-                        (180., 90.).into(),
-                    ),
-                    time_interval: TimeInterval::default(),
-                    spatial_resolution: SpatialResolution::zero_point_one(),
-                })
+                .loading_info(VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new_unchecked((-180., -90.).into(), (180., 90.).into()),
+                    TimeInterval::default(),
+                    SpatialResolution::zero_point_one(),
+                ))
                 .await
                 .map_err(|e| e.to_string())?;
 

--- a/services/src/datasets/external/nature40.rs
+++ b/services/src/datasets/external/nature40.rs
@@ -517,8 +517,7 @@ mod tests {
 
     use geoengine_datatypes::{
         primitives::{
-            CacheTtlSeconds, Measurement, QueryRectangle, SpatialPartition2D, SpatialResolution,
-            TimeInterval,
+            CacheTtlSeconds, Measurement, SpatialPartition2D, SpatialResolution, TimeInterval,
         },
         raster::RasterDataType,
         spatial_reference::{SpatialReference, SpatialReferenceAuthority},
@@ -930,17 +929,17 @@ mod tests {
         );
 
         let loading_info = meta
-            .loading_info(QueryRectangle {
-                spatial_bounds: SpatialPartition2D::new_unchecked(
+            .loading_info(RasterQueryRectangle::with_partition_and_resolution(
+                SpatialPartition2D::new_unchecked(
                     (473_922.500, 5_634_057.500).into(),
                     (473_924.500, 5_634_055.50).into(),
                 ),
-                time_interval: TimeInterval::default(),
-                spatial_resolution: SpatialResolution::new_unchecked(
+                SpatialResolution::new_unchecked(
                     (473_924.500 - 473_922.500) / 2.,
                     (5_634_057.500 - 5_634_055.50) / 2.,
                 ),
-            })
+                TimeInterval::default(),
+            ))
             .await
             .unwrap();
 

--- a/services/src/datasets/external/netcdfcf/mod.rs
+++ b/services/src/datasets/external/netcdfcf/mod.rs
@@ -1969,18 +1969,18 @@ mod tests {
         );
 
         let loading_info = metadata
-            .loading_info(RasterQueryRectangle {
-                spatial_bounds: SpatialPartition2D::new(
+            .loading_info(RasterQueryRectangle::with_partition_and_resolution(
+                SpatialPartition2D::new(
                     (43.945_312_5, 0.791_015_625_25).into(),
                     (44.033_203_125, 0.703_125_25).into(),
                 )
                 .unwrap(),
-                time_interval: TimeInstance::from(DateTime::new_utc(2001, 4, 1, 0, 0, 0)).into(),
-                spatial_resolution: SpatialResolution::new_unchecked(
+                SpatialResolution::new_unchecked(
                     0.000_343_322_7, // 256 pixel
                     0.000_343_322_7, // 256 pixel
                 ),
-            })
+                TimeInstance::from(DateTime::new_utc(2001, 4, 1, 0, 0, 0)).into(),
+            ))
             .await
             .unwrap();
 
@@ -2096,18 +2096,18 @@ mod tests {
         );
 
         let loading_info = metadata
-            .loading_info(RasterQueryRectangle {
-                spatial_bounds: SpatialPartition2D::new(
+            .loading_info(RasterQueryRectangle::with_partition_and_resolution(
+                SpatialPartition2D::new(
                     (43.945_312_5, 0.791_015_625_25).into(),
                     (44.033_203_125, 0.703_125_25).into(),
                 )
                 .unwrap(),
-                time_interval: TimeInstance::from(DateTime::new_utc(2001, 4, 1, 0, 0, 0)).into(),
-                spatial_resolution: SpatialResolution::new_unchecked(
+                SpatialResolution::new_unchecked(
                     0.000_343_322_7, // 256 pixel
                     0.000_343_322_7, // 256 pixel
                 ),
-            })
+                TimeInstance::from(DateTime::new_utc(2001, 4, 1, 0, 0, 0)).into(),
+            ))
             .await
             .unwrap();
 
@@ -2313,19 +2313,19 @@ mod tests {
 
         let result = processor
             .plot_query(
-                PlotQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new(
+                PlotQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new(
                         (46.478_278_849, 40.584_655_660_000_1).into(),
                         (87.323_796_021_000_1, 55.434_550_273).into(),
                     )
                     .unwrap(),
-                    time_interval: TimeInterval::new(
+                    TimeInterval::new(
                         DateTime::new_utc(1900, 4, 1, 0, 0, 0),
                         DateTime::new_utc_with_millis(2055, 4, 1, 0, 0, 0, 1),
                     )
                     .unwrap(),
-                    spatial_resolution: SpatialResolution::new_unchecked(0.1, 0.1),
-                },
+                    SpatialResolution::new_unchecked(0.1, 0.1),
+                ),
                 &query_context,
             )
             .await

--- a/services/src/datasets/external/pangaea/mod.rs
+++ b/services/src/datasets/external/pangaea/mod.rs
@@ -466,11 +466,11 @@ mod tests {
             panic!("Expected Data QueryProcessor");
         };
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
         let ctx = MockQueryContext::test_default();
 
         let result = proc.query(query_rectangle, &ctx).await;
@@ -530,11 +530,11 @@ mod tests {
             panic!("Expected MultiPoint QueryProcessor");
         };
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
         let ctx = MockQueryContext::test_default();
 
         let result: Vec<MultiPointCollection> = proc
@@ -605,11 +605,11 @@ mod tests {
             panic!("Expected MultiPolygon QueryProcessor");
         };
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
         let ctx = MockQueryContext::test_default();
 
         let result: Vec<MultiPolygonCollection> = proc
@@ -675,11 +675,11 @@ mod tests {
             panic!("Expected MultiPoint QueryProcessor");
         };
 
-        let query_rectangle = VectorQueryRectangle {
-            spatial_bounds: BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
-            time_interval: TimeInterval::default(),
-            spatial_resolution: SpatialResolution::zero_point_one(),
-        };
+        let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+            BoundingBox2D::new((-180., -90.).into(), (180., 90.).into()).unwrap(),
+            TimeInterval::default(),
+            SpatialResolution::zero_point_one(),
+        );
         let ctx = MockQueryContext::test_default();
 
         let result: Vec<MultiPointCollection> = proc

--- a/services/src/handlers/datasets.rs
+++ b/services/src/handlers/datasets.rs
@@ -1444,14 +1444,11 @@ mod tests {
 
                 let query = query_processor
                     .query(
-                        VectorQueryRectangle {
-                            spatial_bounds: BoundingBox2D::new(
-                                (1.85, 50.88).into(),
-                                (4.82, 52.95).into(),
-                            )?,
-                            time_interval: Default::default(),
-                            spatial_resolution: SpatialResolution::new(1., 1.)?,
-                        },
+                        VectorQueryRectangle::with_bounds_and_resolution(
+                            BoundingBox2D::new((1.85, 50.88).into(), (4.82, 52.95).into())?,
+                            Default::default(),
+                            SpatialResolution::new(1., 1.)?,
+                        ),
                         &query_ctx,
                     )
                     .await

--- a/services/src/handlers/wcs.rs
+++ b/services/src/handlers/wcs.rs
@@ -433,11 +433,13 @@ async fn wcs_get_coverage_handler<C: ApplicationContext>(
             }
         };
 
-    let query_rect = RasterQueryRectangle {
-        spatial_bounds: request_partition,
-        time_interval: request.time.unwrap_or_else(default_time_from_config).into(),
+    // FIXME: we query with a grid that is snapped to the grid origin. We COULD also query with the origin of the query OR the native origin of the workflow.
+    let query_rect = RasterQueryRectangle::with_partition_and_resolution_and_origin(
+        request_partition,
         spatial_resolution,
-    };
+        execution_context.tiling_specification().origin_coordinate,
+        request.time.unwrap_or_else(default_time_from_config).into(),
+    );
 
     let query_ctx = ctx.query_context()?;
 

--- a/services/src/handlers/wfs.rs
+++ b/services/src/handlers/wfs.rs
@@ -519,14 +519,14 @@ async fn wfs_feature_handler<C: ApplicationContext>(
 
     let processor = initialized.query_processor().context(error::Operator)?;
 
-    let query_rect = VectorQueryRectangle {
-        spatial_bounds: request.bbox.bounds_naive()?,
-        time_interval: request.time.unwrap_or_else(default_time_from_config).into(),
+    let query_rect = VectorQueryRectangle::with_bounds_and_resolution(
+        request.bbox.bounds_naive()?,
+        request.time.unwrap_or_else(default_time_from_config).into(),
         // TODO: find reasonable default
-        spatial_resolution: request
+        request
             .query_resolution
             .map_or_else(SpatialResolution::zero_point_one, |r| r.0),
-    };
+    );
     let query_ctx = ctx.query_context()?;
 
     let (json, cache_hint) = match processor {

--- a/services/src/pro/contexts/postgres.rs
+++ b/services/src/pro/contexts/postgres.rs
@@ -1174,14 +1174,11 @@ let ctx = app_ctx.session_context(session);
 
             assert_eq!(
                 meta_data
-                    .loading_info(VectorQueryRectangle {
-                        spatial_bounds: BoundingBox2D::new_unchecked(
-                            (-180., -90.).into(),
-                            (180., 90.).into()
-                        ),
-                        time_interval: TimeInterval::default(),
-                        spatial_resolution: SpatialResolution::zero_point_one(),
-                    })
+                    .loading_info(VectorQueryRectangle::with_bounds_and_resolution(
+                        BoundingBox2D::new_unchecked((-180., -90.).into(), (180., 90.).into()),
+                        TimeInterval::default(),
+                        SpatialResolution::zero_point_one(),
+                    ))
                     .await
                     .unwrap(),
                 loading_info

--- a/services/src/pro/handlers/datasets.rs
+++ b/services/src/pro/handlers/datasets.rs
@@ -347,14 +347,11 @@ mod tests {
 
                 let query = query_processor
                     .query(
-                        VectorQueryRectangle {
-                            spatial_bounds: BoundingBox2D::new(
-                                (1.85, 50.88).into(),
-                                (4.82, 52.95).into(),
-                            )?,
-                            time_interval: Default::default(),
-                            spatial_resolution: SpatialResolution::new(1., 1.)?,
-                        },
+                        VectorQueryRectangle::with_bounds_and_resolution(
+                            BoundingBox2D::new((1.85, 50.88).into(), (4.82, 52.95).into())?,
+                            Default::default(),
+                            SpatialResolution::new(1., 1.)?,
+                        ),
                         &query_ctx,
                     )
                     .await

--- a/services/src/workflows/vector_stream.rs
+++ b/services/src/workflows/vector_stream.rs
@@ -275,18 +275,15 @@ mod tests {
                     ),
                 };
 
-                let query_rectangle = VectorQueryRectangle {
-                    spatial_bounds: BoundingBox2D::new_upper_left_lower_right(
+                let query_rectangle = VectorQueryRectangle::with_bounds_and_resolution(
+                    BoundingBox2D::new_upper_left_lower_right(
                         (-180., 90.).into(),
                         (180., -90.).into(),
                     )
                     .unwrap(),
-                    time_interval: TimeInterval::new_instant(DateTime::new_utc(
-                        2014, 3, 1, 0, 0, 0,
-                    ))
-                    .unwrap(),
-                    spatial_resolution: SpatialResolution::one(),
-                };
+                    TimeInterval::new_instant(DateTime::new_utc(2014, 3, 1, 0, 0, 0)).unwrap(),
+                    SpatialResolution::one(),
+                );
 
                 let handler = VectorWebsocketStreamHandler::new::<PostgresSessionContext<NoTls>>(
                     workflow.operator.get_vector().unwrap(),


### PR DESCRIPTION
- [ ] I added an entry to [`CHANGELOG.md`](CHANGELOG.md) if knowledge of this change could be valuable to users.

---

Here is a brief summary of what I did:


- This PR changes the QueryRectangle struct to combine a temporal and a spatial query.
- All QueryRectangles are now created using a static constructor method.
- VectorQueryRectangle use the same components as before just different composition.
- RasterQueryRectangle now use a GeoTransform and GridBounds in Pixels. (not finished yet, origin should come from result descriptor)

