### PR TITLE
check dataset name before task

### DIFF
--- a/services/src/api/handlers/wms.rs
+++ b/services/src/api/handlers/wms.rs
@@ -578,6 +578,7 @@ mod tests {
                 ctx.db()
                     .resolve_dataset_name_to_id(&DatasetName::new(None, "NDVI"))
                     .await
+                    .unwrap()
                     .unwrap(),
             )
             .await
@@ -685,6 +686,7 @@ mod tests {
                 ctx.db()
                     .resolve_dataset_name_to_id(&DatasetName::new(None, "NDVI"))
                     .await
+                    .unwrap()
                     .unwrap(),
             )
             .await

--- a/services/src/api/handlers/workflows.rs
+++ b/services/src/api/handlers/workflows.rs
@@ -858,6 +858,7 @@ mod tests {
                 ctx.db()
                     .resolve_dataset_name_to_id(&DatasetName::new(None, "NDVI"))
                     .await
+                    .unwrap()
                     .unwrap(),
             )
             .await

--- a/services/src/contexts/mod.rs
+++ b/services/src/contexts/mod.rs
@@ -273,6 +273,10 @@ where
                 },
             )?;
 
+        // handle the case where the dataset name is not known
+        let dataset_id = dataset_id
+            .ok_or(geoengine_operators::error::Error::UnknownDatasetName { name: data.clone() })?;
+
         Ok(dataset_id.into())
     }
 

--- a/services/src/contexts/postgres.rs
+++ b/services/src/contexts/postgres.rs
@@ -2350,7 +2350,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            db.resolve_dataset_name_to_id(&dataset_name1).await.unwrap(),
+            db.resolve_dataset_name_to_id(&dataset_name1)
+                .await
+                .unwrap()
+                .unwrap(),
             dataset_id1
         );
     }

--- a/services/src/datasets/create_from_workflow.rs
+++ b/services/src/datasets/create_from_workflow.rs
@@ -190,14 +190,15 @@ pub async fn schedule_raster_dataset_from_workflow_task<C: SessionContext>(
     if let Some(dataset_name) = &info.name {
         let db = ctx.db();
 
-        let potential_id = db.resolve_dataset_name_to_id(dataset_name).await;
+        // try to resolve the dataset name to an id
+        let potential_id_result = db.resolve_dataset_name_to_id(dataset_name).await?;
 
-        if let Ok(id) = potential_id {
-            return crate::error::DatasetNameAlreadyExists {
+        // handle the case where the dataset name is already taken
+        if let Some(dataset_id) = potential_id_result {
+            return Err(error::Error::DatasetNameAlreadyExists {
                 dataset_name: dataset_name.to_string(),
-                dataset_id: id,
-            }
-            .fail();
+                dataset_id: dataset_id.into(),
+            });
         }
     }
 

--- a/services/src/datasets/listing.rs
+++ b/services/src/datasets/listing.rs
@@ -80,7 +80,7 @@ pub trait DatasetProvider: Send
 
     async fn load_provenance(&self, dataset: &DatasetId) -> Result<ProvenanceOutput>;
 
-    async fn resolve_dataset_name_to_id(&self, name: &DatasetName) -> Result<DatasetId>;
+    async fn resolve_dataset_name_to_id(&self, name: &DatasetName) -> Result<Option<DatasetId>>;
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, ToSchema)]

--- a/services/src/error.rs
+++ b/services/src/error.rs
@@ -214,6 +214,10 @@ pub enum Error {
         dataset_name: String,
         dataset_id: DatasetId,
     },
+    #[snafu(display("Dataset name '{}' does not exist", dataset_name))]
+    UnknownDatasetName {
+        dataset_name: String,
+    },
     InvalidDatasetName,
     DatasetInvalidLayerName {
         layer_name: String,

--- a/services/src/error.rs
+++ b/services/src/error.rs
@@ -209,6 +209,11 @@ pub enum Error {
     InvalidUploadFileName,
     InvalidDatasetIdNamespace,
     DuplicateDatasetId,
+    #[snafu(display("Dataset name '{}' already exists", dataset_name))]
+    DatasetNameAlreadyExists {
+        dataset_name: String,
+        dataset_id: DatasetId,
+    },
     InvalidDatasetName,
     DatasetInvalidLayerName {
         layer_name: String,

--- a/services/src/pro/api/handlers/datasets.rs
+++ b/services/src/pro/api/handlers/datasets.rs
@@ -438,7 +438,11 @@ mod tests {
             construct_dataset_from_upload(app_ctx.clone(), upload_id, session_id).await;
 
         let db = ctx.db();
-        let dataset_id = db.resolve_dataset_name_to_id(&dataset_name).await.unwrap();
+        let dataset_id = db
+            .resolve_dataset_name_to_id(&dataset_name)
+            .await
+            .unwrap()
+            .unwrap();
 
         assert!(db.load_dataset(&dataset_id).await.is_ok());
 
@@ -495,7 +499,11 @@ mod tests {
         let res = send_pro_test_request(req, app_ctx.clone()).await;
 
         let DatasetNameResponse { dataset_name } = actix_web::test::read_body_json(res).await;
-        let dataset_id = db.resolve_dataset_name_to_id(&dataset_name).await.unwrap();
+        let dataset_id = db
+            .resolve_dataset_name_to_id(&dataset_name)
+            .await
+            .unwrap()
+            .unwrap();
 
         assert!(db.load_dataset(&dataset_id).await.is_ok());
 

--- a/services/src/pro/api/handlers/permissions.rs
+++ b/services/src/pro/api/handlers/permissions.rs
@@ -55,7 +55,11 @@ impl Resource {
             }
             Resource::Project(project_id) => ResourceId::Project(project_id),
             Resource::Dataset(dataset_name) => {
-                ResourceId::DatasetId(db.resolve_dataset_name_to_id(&dataset_name).await?)
+                ResourceId::DatasetId(db.resolve_dataset_name_to_id(&dataset_name).await?.ok_or(
+                    crate::error::Error::UnknownDatasetName {
+                        dataset_name: dataset_name.to_string(),
+                    },
+                )?)
             }
         })
     }

--- a/services/src/pro/contexts/mod.rs
+++ b/services/src/pro/contexts/mod.rs
@@ -188,6 +188,10 @@ where
                 },
             )?;
 
+        // handle the case where the dataset name is not known
+        let dataset_id = dataset_id
+            .ok_or(geoengine_operators::error::Error::UnknownDatasetName { name: data.clone() })?;
+
         Ok(dataset_id.into())
     }
 

--- a/services/src/pro/contexts/postgres.rs
+++ b/services/src/pro/contexts/postgres.rs
@@ -3453,11 +3453,17 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            db.resolve_dataset_name_to_id(&dataset_name1).await.unwrap(),
+            db.resolve_dataset_name_to_id(&dataset_name1)
+                .await
+                .unwrap()
+                .unwrap(),
             dataset_id1
         );
         assert_eq!(
-            db.resolve_dataset_name_to_id(&dataset_name2).await.unwrap(),
+            db.resolve_dataset_name_to_id(&dataset_name2)
+                .await
+                .unwrap()
+                .unwrap(),
             dataset_id2
         );
     }

--- a/services/src/pro/datasets/postgres.rs
+++ b/services/src/pro/datasets/postgres.rs
@@ -209,7 +209,10 @@ where
         })
     }
 
-    async fn resolve_dataset_name_to_id(&self, dataset_name: &DatasetName) -> Result<DatasetId> {
+    async fn resolve_dataset_name_to_id(
+        &self,
+        dataset_name: &DatasetName,
+    ) -> Result<Option<DatasetId>> {
         let conn = self.conn_pool.get().await?;
         resolve_dataset_name_to_id(&conn, dataset_name).await
     }


### PR DESCRIPTION
- [ ] I added an entry to [`CHANGELOG.md`](CHANGELOG.md) if knowledge of this change could be valuable to users.

---

Here is a brief summary of what I did:

Added a check to layer_to_dataset / workflow_to_dataset that tests if a dataset name already exists. If the name is already in use an error is returned and no task is created.
