### PR TITLE
Increase SQL linter file size;

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -2,3 +2,4 @@
 dialect = postgres
 templater = jinja
 sql_file_exts = .sql
+large_file_skip_byte_limit = 40000


### PR DESCRIPTION
- [ ] I added an entry to [`CHANGELOG.md`](CHANGELOG.md) if knowledge of this change could be valuable to users.

---

Here is a brief summary of what I did:

- Increased the number of bytes for files in the sql linter such that the current_schema file is not skipped.