### PR TITLE
SparseTilesFillAdapter: add requested bounds, fill only if needed

### DIFF
--- a/operators/src/adapters/raster_subquery/raster_subquery_adapter.rs
+++ b/operators/src/adapters/raster_subquery/raster_subquery_adapter.rs
@@ -196,6 +196,7 @@ where
             global_geo_transform,
             tile_shape,
             cache_expiration,
+            query_time_bounds,
             FillerTimeBounds::from(query_time_bounds), // operator should at least fill the query rect. Adapter will handle overflow at start / end gracefully.
         );
         s_filled.boxed()

--- a/operators/src/adapters/sparse_tiles_fill_adapter.rs
+++ b/operators/src/adapters/sparse_tiles_fill_adapter.rs
@@ -98,7 +98,8 @@ struct StateContainer<T> {
     global_geo_transform: GeoTransform,
     state: State,
     cache_hint: FillerTileCacheHintProvider,
-    time_bounds: FillerTimeBounds,
+    requested_time_bounds: TimeInterval,
+    data_time_bounds: FillerTimeBounds,
 }
 
 struct GridIdxAndBand {
@@ -267,32 +268,33 @@ impl<T: Pixel> StateContainer<T> {
     fn set_current_time_from_initial_tile(&mut self, first_tile_time: TimeInterval) {
         // if we know a bound we must use it to set the current time
 
-        let start_bound = self.time_bounds.start();
-        if start_bound < first_tile_time.start() {
+        let start_data_bound = self.data_time_bounds.start();
+        let requested_start = self.requested_time_bounds.start();
+        if requested_start < first_tile_time.start() {
             log::debug!(
-                    "The initial tile starts ({}) after the start bound ({}), setting the current time to the start bound --> filling", first_tile_time.start(), start_bound
+                    "The initial tile starts ({}) after the requested start bound ({}), setting the current time to the data start bound ({}) --> filling", first_tile_time.start(), requested_start, start_data_bound
                 );
             self.current_time = Some(TimeInterval::new_unchecked(
-                start_bound,
+                start_data_bound,
                 first_tile_time.start(),
             ));
             return;
         }
-        if start_bound > first_tile_time.start() {
+        if start_data_bound > first_tile_time.start() {
             log::debug!(
                     "The initial tile time start ({}) is before the exprected time bounds ({}). This means the data overflows the filler start bound.",
                     first_tile_time.start(),
-                    start_bound
+                    start_data_bound
                 );
         }
         self.current_time = Some(first_tile_time);
     }
 
-    fn set_current_time_from_bounds(&mut self) {
+    fn set_current_time_from_data_time_bounds(&mut self) {
         assert!(self.state == State::FillToEnd);
         self.current_time = Some(TimeInterval::new_unchecked(
-            self.time_bounds.start(),
-            self.time_bounds.end(),
+            self.data_time_bounds.start(),
+            self.data_time_bounds.end(),
         ));
     }
 
@@ -319,21 +321,24 @@ impl<T: Pixel> StateContainer<T> {
         let current_time: TimeInterval = self
             .current_time
             .expect("current time must exist for fill to end state.");
-        debug_assert!(current_time.end() < self.time_bounds.end());
+        debug_assert!(current_time.end() <= self.requested_time_bounds.end());
+
+        debug_assert!(current_time.end() < self.data_time_bounds.end());
 
         let new_time = if current_time.is_instant() {
-            TimeInterval::new_unchecked(current_time.end() + 1, self.time_bounds.end())
+            TimeInterval::new_unchecked(current_time.end() + 1, self.data_time_bounds.end())
         } else {
-            TimeInterval::new_unchecked(current_time.end(), self.time_bounds.end())
+            TimeInterval::new_unchecked(current_time.end(), self.data_time_bounds.end())
         };
         self.update_current_time(new_time);
     }
 
     fn current_time_is_valid_end_bound(&self) -> bool {
-        let time_bounds_end = self.time_bounds.end();
+        let time_requested_end = self.requested_time_bounds.end();
+        let time_bounds_end = self.data_time_bounds.end();
         let current_time = self.current_time.expect("state time is set on initialize");
 
-        if current_time.end() < time_bounds_end {
+        if current_time.end() < time_requested_end {
             return false;
         }
         if current_time.end() > time_bounds_end {
@@ -361,6 +366,7 @@ where
     T: Pixel,
     S: Stream<Item = Result<RasterTile2D<T>>>,
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         stream: S,
         tile_grid_bounds: GridBoundingBox2D,
@@ -368,7 +374,8 @@ where
         global_geo_transform: GeoTransform,
         tile_shape: GridShape2D,
         cache_expiration: FillerTileCacheExpirationStrategy, // Specifies the cache expiration for the produced filler tiles. Set this to unlimited if the filler tiles will always be empty
-        time_bounds: FillerTimeBounds,
+        requested_time_bounds: TimeInterval,
+        data_time_bounds: FillerTimeBounds,
     ) -> Self {
         SparseTilesFillAdapter {
             stream,
@@ -383,7 +390,8 @@ where
                 no_data_grid: EmptyGrid2D::new(tile_shape),
                 state: State::Initial,
                 cache_hint: cache_expiration.into(),
-                time_bounds,
+                requested_time_bounds,
+                data_time_bounds,
             },
         }
     }
@@ -410,6 +418,7 @@ where
             tiling_strat.geo_transform,
             tiling_spec.tile_size_in_pixels,
             cache_expiration,
+            query_rect_to_answer.time_interval,
             time_bounds,
         )
     }
@@ -437,7 +446,6 @@ where
                 // poll for a first (input) tile
                 let result_tile = match ready!(this.stream.as_mut().poll_next(cx)) {
                     Some(Ok(tile)) => {
-                        // this is the first tile ever
                         // now we have to inspect the time we got and the bound we need to fill. If there are bounds known, then we need to check if the tile starts with the bounds.
                         this.sc.set_current_time_from_initial_tile(tile.time);
 
@@ -468,7 +476,7 @@ where
                     None => {
                         debug_assert!(this.sc.current_idx == min_idx);
                         this.sc.state = State::FillToEnd;
-                        this.sc.set_current_time_from_bounds();
+                        this.sc.set_current_time_from_data_time_bounds();
                         this.sc.current_no_data_tile()
                     }
                 };
@@ -503,11 +511,11 @@ where
                             .into(),
                         )));
                         }
-                        if tile.time.start() >= this.sc.time_bounds.end() {
+                        if tile.time.start() >= this.sc.requested_time_bounds.end() {
                             log::warn!(
-                                    "The tile time start ({}) is outside of the expected time bounds ({})!",
-                                    tile.time.end(),
-                                    this.sc.time_bounds.start()
+                                    "The tile time start ({}) is outside of the requested time bounds ({})!",
+                                    tile.time.start(),
+                                    this.sc.requested_time_bounds.end()
                                 );
                         }
 
@@ -911,6 +919,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::NoCache,
+            TimeInterval::new_unchecked(5, 10),
             FillerTimeBounds::from(TimeInterval::new_unchecked(5, 10)),
         );
 
@@ -960,6 +969,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::NoCache,
+            TimeInterval::default(),
             FillerTimeBounds::from(TimeInterval::default()),
         );
 
@@ -1046,6 +1056,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::NoCache,
+            TimeInterval::new_unchecked(0, 10),
             FillerTimeBounds::from(TimeInterval::new_unchecked(0, 10)),
         );
 
@@ -1165,6 +1176,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::NoCache,
+            TimeInterval::new_unchecked(0, 10),
             FillerTimeBounds::from(TimeInterval::new_unchecked(0, 10)),
         );
 
@@ -1255,6 +1267,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::NoCache,
+            TimeInterval::new_unchecked(0, 10),
             FillerTimeBounds::from(TimeInterval::new_unchecked(0, 10)),
         );
 
@@ -1321,6 +1334,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::NoCache,
+            TimeInterval::new_unchecked(0, 10),
             FillerTimeBounds::from(TimeInterval::new_unchecked(0, 10)),
         );
 
@@ -1442,6 +1456,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::NoCache,
+            TimeInterval::new_unchecked(0, 10),
             FillerTimeBounds::from(TimeInterval::new_unchecked(0, 10)),
         );
 
@@ -1508,6 +1523,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::NoCache,
+            TimeInterval::default(),
             FillerTimeBounds::from(TimeInterval::default()),
         );
 
@@ -1560,6 +1576,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::NoCache,
+            TimeInterval::new_unchecked(0, 5),
             FillerTimeBounds::from(TimeInterval::new_unchecked(0, 5)),
         );
 
@@ -1670,6 +1687,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::NoCache,
+            TimeInterval::new_unchecked(0, 15),
             FillerTimeBounds::from(TimeInterval::new_unchecked(0, 15)),
         );
 
@@ -1741,6 +1759,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::NoCache,
+            TimeInterval::new_unchecked(0, 15),
             FillerTimeBounds::from(TimeInterval::new_unchecked(0, 15)),
         );
 
@@ -1838,6 +1857,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::NoCache,
+            TimeInterval::new_unchecked(0, 10),
             FillerTimeBounds::from(TimeInterval::new_unchecked(0, 10)),
         );
 
@@ -1931,6 +1951,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::DerivedFromSurroundingTiles,
+            TimeInterval::new_unchecked(0, 10),
             FillerTimeBounds::from(TimeInterval::new_unchecked(0, 10)),
         );
 
@@ -1978,6 +1999,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::DerivedFromSurroundingTiles,
+            TimeInterval::new_unchecked(0, 10),
             FillerTimeBounds::from(TimeInterval::new_unchecked(0, 10)),
         );
 
@@ -2033,6 +2055,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::NoCache,
+            TimeInterval::new_unchecked(0, 10),
             FillerTimeBounds::from(TimeInterval::new_unchecked(0, 10)),
         );
 
@@ -2104,6 +2127,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::NoCache,
+            TimeInterval::new_unchecked(0, 10),
             FillerTimeBounds::from(TimeInterval::new_unchecked(0, 10)),
         );
 
@@ -2252,6 +2276,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::NoCache,
+            TimeInterval::new_unchecked(0, 5),
             FillerTimeBounds::from(TimeInterval::new_unchecked(0, 5)),
         );
 
@@ -2360,6 +2385,7 @@ mod tests {
             global_geo_transform,
             tile_shape,
             FillerTileCacheExpirationStrategy::NoCache,
+            TimeInterval::new_unchecked(0, 1),
             FillerTimeBounds::from(TimeInterval::new_unchecked(0, 1)),
         );
 

--- a/operators/src/adapters/sparse_tiles_fill_adapter.rs
+++ b/operators/src/adapters/sparse_tiles_fill_adapter.rs
@@ -267,9 +267,14 @@ impl<T: Pixel> StateContainer<T> {
 
     fn set_current_time_from_initial_tile(&mut self, first_tile_time: TimeInterval) {
         // if we know a bound we must use it to set the current time
-
         let start_data_bound = self.data_time_bounds.start();
         let requested_start = self.requested_time_bounds.start();
+
+        debug_assert!(
+            start_data_bound <= requested_start,
+            "The data bound hint start should be <= the requested start. "
+        );
+
         if requested_start < first_tile_time.start() {
             log::debug!(
                     "The initial tile starts ({}) after the requested start bound ({}), setting the current time to the data start bound ({}) --> filling", first_tile_time.start(), requested_start, start_data_bound
@@ -377,6 +382,15 @@ where
         requested_time_bounds: TimeInterval,
         data_time_bounds: FillerTimeBounds,
     ) -> Self {
+        debug_assert!(
+            data_time_bounds.start <= requested_time_bounds.start(),
+            "Data time bounds hint start should be <= requested time start."
+        );
+        debug_assert!(
+            requested_time_bounds.end() <= data_time_bounds.end,
+            "Data time bounds hint end should be >= requested time end."
+        );
+
         SparseTilesFillAdapter {
             stream,
             sc: StateContainer {

--- a/operators/src/mock/mock_raster_source.rs
+++ b/operators/src/mock/mock_raster_source.rs
@@ -175,6 +175,7 @@ where
             tiling_strategy.geo_transform,
             tiling_strategy.tile_size_in_pixels,
             FillerTileCacheExpirationStrategy::FixedValue(CacheExpiration::max()), // cache forever because we know all mock data
+            query.time_interval,
             FillerTimeBounds::new(known_time_before, known_time_after),
         )
         .boxed())

--- a/operators/src/processing/reprojection.rs
+++ b/operators/src/processing/reprojection.rs
@@ -657,6 +657,7 @@ where
                 tiling_strat.geo_transform,
                 self.tiling_spec.tile_size_in_pixels,
                 FillerTileCacheExpirationStrategy::DerivedFromSurroundingTiles,
+                query.time_interval,
                 FillerTimeBounds::from(query.time_interval), // TODO: derive this from the query once the child query can provide this.
             )))
         }


### PR DESCRIPTION
- [ ] I added an entry to [`CHANGELOG.md`](CHANGELOG.md) if knowledge of this change could be valuable to users.

---

Here is a brief summary of what I did:

- Added requested time bounds to SparseTilesFillAdapter
- Adjust adapter to only fill in requested time ranges
- StacSentinel2Provider. clip times on full days to avoid wrong aggregations
