### PR TITLE
fix: Still serve preline in production build

### DIFF
--- a/www/justfile
+++ b/www/justfile
@@ -16,9 +16,11 @@ upgrade: common::_clear
 build: common::_clear
     npm run build
 
+# Serve the website in development mode with hot reloading, or start the preview server if the "--preview" flag. Usage: `just run` or `just run --preview`
+[arg("preview", long="preview", value="true", help="Whether to start the preview instead of the dev server.")]
 [group("run")]
-run: common::_clear
-    npm run dev
+run preview="false": common::_clear
+    {{ if preview == "true" { "npm run build && npm run preview" } else { "npm run dev" } }}
 
 lint: common::_clear format
     npm run eslint

--- a/www/src/layouts/SiteLayout.astro
+++ b/www/src/layouts/SiteLayout.astro
@@ -17,9 +17,21 @@ import Footer from '../components/Footer.astro';
         <Header />
         <slot />
         <Footer />
+
+        <!-- Preline UI -->
+        <script>
+            import {HSStaticMethods} from 'preline/dist/preline.js';
+
+            // Explicitly calling a method from the import prevents tree-shaking
+            const init = () => {
+                HSStaticMethods.autoInit();
+            };
+
+            // Standard Astro lifecycle event
+            document.addEventListener('astro:page-load', init);
+
+            // Re-init after transitions
+            document.addEventListener('astro:after-swap', init);
+        </script>
     </body>
-    <!-- Preline UI -->
-    <script>
-        import 'preline/dist/preline.js';
-    </script>
 </html>


### PR DESCRIPTION
Make Astro not lose preline due to treeshaking in production build.