### PR TITLE
feat: external data path

### DIFF
--- a/geoengine/operators/src/source/gdal_worker_process/gdal_dataset_params.rs
+++ b/geoengine/operators/src/source/gdal_worker_process/gdal_dataset_params.rs
@@ -77,8 +77,32 @@ impl GdalDatasetParameters {
         SpatialGridDefinition::new(gdal_geo_transform, self.dataset_bounds())
     }
 
-    pub fn is_vis_curl(&self) -> bool {
-        self.file_path.starts_with("/vsicurl/") || self.file_path.starts_with("/vsis3/")
+    /// Returns the file path that should be passed to GDAL when opening the dataset.
+    ///
+    /// Remote HTTP(S) and S3 URLs are wrapped in the corresponding GDAL virtual file
+    /// system handler (`/vsicurl/` for `http://`/`https://`, `/vsis3/` for `s3://`).
+    /// Local file paths and already-prefixed paths (e.g. `/vsicurl_streaming/`) are
+    /// returned unchanged.
+    pub fn file_path_for_open(&self) -> PathBuf {
+        let file_path_str = self.file_path.to_string_lossy();
+
+        if let Some(s3_path) = file_path_str.strip_prefix("s3://") {
+            PathBuf::from(format!("/vsis3/{s3_path}"))
+        } else if file_path_str.starts_with("http://") || file_path_str.starts_with("https://") {
+            PathBuf::from(format!("/vsicurl/{file_path_str}"))
+        } else {
+            self.file_path.clone()
+        }
+    }
+
+    /// Returns whether the file path refers to a remote resource that is accessed via
+    /// a GDAL virtual file system handler (HTTP(S) or S3). Used to decide whether the
+    /// VSI cache needs to be cleared on retry.
+    pub fn is_remote(&self) -> bool {
+        let file_path_str = self.file_path.to_string_lossy();
+        file_path_str.starts_with("http://")
+            || file_path_str.starts_with("https://")
+            || file_path_str.starts_with("s3://")
     }
 
     /// Returns the request-level GDAL config options supplied by the user.

--- a/geoengine/operators/src/source/gdal_worker_process/process_impl.rs
+++ b/geoengine/operators/src/source/gdal_worker_process/process_impl.rs
@@ -254,7 +254,7 @@ impl GdalDatasetHolder {
             .expect("GdalConfigOptions must not fail");
 
         let ds = gdal_open_ex_gdal_error(
-            &dataset_params.file_path,
+            &dataset_params.file_path_for_open(),
             DatasetOptions {
                 open_flags: GdalOpenFlags::GDAL_OF_RASTER,
                 open_options: options.as_deref(),
@@ -368,7 +368,7 @@ impl GdalHandling {
         dataset_params: &GdalDatasetParameters,
         read_advise: GdalReadAdvise,
     ) -> Result<super::process_common::GdalIpcPayload<T>, IpcProcessError> {
-        let is_vsi_curl = dataset_params.is_vis_curl();
+        let is_remote = dataset_params.is_remote();
         let max_retries = dataset_params.max_retries().unwrap_or(0);
         let dp = &dataset_params;
 
@@ -383,16 +383,16 @@ impl GdalHandling {
                 let ds = match cache.get_or_open(dp) {
                     Ok(dataset) => dataset,
                     Err(gdal_error) => {
-                        if is_vsi_curl {
-                            Self::clear_gdal_vsi_cache_for_path(dp.file_path.as_path());
+                        if is_remote {
+                            Self::clear_gdal_vsi_cache_for_path(&dp.file_path_for_open());
                         }
                         return Err(IpcProcessError::from(gdal_error));
                     }
                 };
 
                 Self::load_tile_data(ds, dataset_params, read_advise).inspect_err(|_e| {
-                    if is_vsi_curl {
-                        Self::clear_gdal_vsi_cache_for_path(dp.file_path.as_path());
+                    if is_remote {
+                        Self::clear_gdal_vsi_cache_for_path(&dp.file_path_for_open());
                     }
                 })
             },
@@ -1195,7 +1195,7 @@ mod tests {
         );
 
         let ds = GdalDatasetParameters {
-            file_path: format!("/vsicurl/{}", server.url_str("/non_existing.tif")).into(),
+            file_path: server.url_str("/non_existing.tif").into(),
             rasterband_channel: 1,
             geo_transform: TestDefault::test_default(),
             width: 100,
@@ -1241,7 +1241,7 @@ mod tests {
         }
 
         let ds = GdalDatasetParameters {
-            file_path: format!("/vsicurl/{}", server.url_str("/internal_error.tif")).into(),
+            file_path: server.url_str("/internal_error.tif").into(),
             rasterband_channel: 1,
             geo_transform: TestDefault::test_default(),
             width: 100,
@@ -1293,22 +1293,37 @@ mod tests {
                 ]),
         );
 
-        let file_path: PathBuf = format!("/vsicurl/{}", server.url_str("/foo.tif")).into();
+        let params = GdalDatasetParameters {
+            file_path: server.url_str("/foo.tif").into(),
+            rasterband_channel: 1,
+            geo_transform: TestDefault::test_default(),
+            width: 100,
+            height: 100,
+            file_not_found_handling: FileNotFoundHandling::NoData,
+            no_data_value: None,
+            properties_mapping: None,
+            gdal_open_options: None,
+            gdal_config_options: Some(vec![
+                (
+                    "CPL_VSIL_CURL_ALLOWED_EXTENSIONS".to_owned(),
+                    ".tif".to_owned(),
+                ),
+                (
+                    "GDAL_DISABLE_READDIR_ON_OPEN".to_owned(),
+                    "EMPTY_DIR".to_owned(),
+                ),
+                ("GDAL_HTTP_NETRC".to_owned(), "NO".to_owned()),
+                ("GDAL_HTTP_MAX_RETRY".to_owned(), "0".to_string()),
+            ]),
+            allow_alphaband_as_mask: true,
+            retry: None,
+        };
 
-        let options = Some(vec![
-            (
-                "CPL_VSIL_CURL_ALLOWED_EXTENSIONS".to_owned(),
-                ".tif".to_owned(),
-            ),
-            (
-                "GDAL_DISABLE_READDIR_ON_OPEN".to_owned(),
-                "EMPTY_DIR".to_owned(),
-            ),
-            ("GDAL_HTTP_NETRC".to_owned(), "NO".to_owned()),
-            ("GDAL_HTTP_MAX_RETRY".to_owned(), "0".to_string()),
-        ]);
+        // The `/vsicurl/` prefix is added when the dataset is opened
+        let file_path = params.file_path_for_open();
 
-        let _thread_local_configs = options
+        let _thread_local_configs = params
+            .gdal_config_options
             .as_ref()
             .map(|config_options| GdalConfigOptions::new(config_options));
 

--- a/geoengine/services/examples/ndvi_remote.rs
+++ b/geoengine/services/examples/ndvi_remote.rs
@@ -8,9 +8,15 @@ use geoengine_datatypes::raster::{
 use geoengine_datatypes::util::gdal::gdal_open_dataset;
 use std::time::{Duration, Instant};
 
-const B04_URL: &str = "/vsicurl/https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MB/2020/8/S2B_32UMB_20200807_1_L2A/B04.tif";
-const B08_URL: &str = "/vsicurl/https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MB/2020/8/S2B_32UMB_20200807_1_L2A/B08.tif";
-const SCL_URL: &str = "/vsicurl/https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MB/2020/8/S2B_32UMB_20200807_1_L2A/SCL.tif";
+const B04_URL: &str = "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MB/2020/8/S2B_32UMB_20200807_1_L2A/B04.tif";
+const B08_URL: &str = "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MB/2020/8/S2B_32UMB_20200807_1_L2A/B08.tif";
+const SCL_URL: &str = "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MB/2020/8/S2B_32UMB_20200807_1_L2A/SCL.tif";
+
+/// Wraps an http(s) URL in GDAL's `/vsicurl/` virtual file system handler.
+/// The prefix is only added when the dataset is actually opened.
+fn vsicurl(url: &str) -> String {
+    format!("/vsicurl/{url}")
+}
 
 struct BandData {
     b04: Vec<u16>,
@@ -154,9 +160,9 @@ fn read_bands(
         ReadStrategy::TiledReusedDataset { tile_size }
         | ReadStrategy::TiledReopenDataset { tile_size } => {
             let reopen_per_tile = matches!(strategy, ReadStrategy::TiledReopenDataset { .. });
-            let scl_dataset = gdal_open_dataset(std::path::Path::new(SCL_URL))?;
-            let b08_dataset = gdal_open_dataset(std::path::Path::new(B08_URL))?;
-            let b04_dataset = gdal_open_dataset(std::path::Path::new(B04_URL))?;
+            let scl_dataset = gdal_open_dataset(std::path::Path::new(&vsicurl(SCL_URL)))?;
+            let b08_dataset = gdal_open_dataset(std::path::Path::new(&vsicurl(B08_URL)))?;
+            let b04_dataset = gdal_open_dataset(std::path::Path::new(&vsicurl(B04_URL)))?;
             read_bands_tiled_internal(
                 &b04_dataset,
                 &b08_dataset,
@@ -183,9 +189,9 @@ fn read_bands_full_raster(
 ) -> Result<(BandData, Duration), Box<dyn std::error::Error>> {
     let start = Instant::now();
 
-    let scl_dataset = gdal_open_dataset(std::path::Path::new(SCL_URL))?;
-    let b08_dataset = gdal_open_dataset(std::path::Path::new(B08_URL))?;
-    let b04_dataset = gdal_open_dataset(std::path::Path::new(B04_URL))?;
+    let scl_dataset = gdal_open_dataset(std::path::Path::new(&vsicurl(SCL_URL)))?;
+    let b08_dataset = gdal_open_dataset(std::path::Path::new(&vsicurl(B08_URL)))?;
+    let b04_dataset = gdal_open_dataset(std::path::Path::new(&vsicurl(B04_URL)))?;
 
     // Read B04 (10m resolution)
     let b04_band = b04_dataset.rasterband(1)?;
@@ -254,9 +260,9 @@ fn read_bands_tiled_internal(
             // Get datasets for this tile (reopen if needed)
             let (b04_ds, b08_ds, scl_ds);
             let (b04_band, b08_band, scl_band) = if reopen_per_tile {
-                b04_ds = gdal_open_dataset(std::path::Path::new(B04_URL))?;
-                b08_ds = gdal_open_dataset(std::path::Path::new(B08_URL))?;
-                scl_ds = gdal_open_dataset(std::path::Path::new(SCL_URL))?;
+                b04_ds = gdal_open_dataset(std::path::Path::new(&vsicurl(B04_URL)))?;
+                b08_ds = gdal_open_dataset(std::path::Path::new(&vsicurl(B08_URL)))?;
+                scl_ds = gdal_open_dataset(std::path::Path::new(&vsicurl(SCL_URL)))?;
                 (
                     b04_ds.rasterband(1)?,
                     b08_ds.rasterband(1)?,

--- a/geoengine/services/examples/ndvi_remote_jp2.rs
+++ b/geoengine/services/examples/ndvi_remote_jp2.rs
@@ -9,9 +9,15 @@ use geoengine_datatypes::util::gdal::gdal_open_dataset;
 use std::time::{Duration, Instant};
 
 const CODE_DE_S3_ENDPOINT: &str = "eodata.nsiscloud.polsa.gov.pl";
-const B04_URL: &str = "/vsis3/eodata/Sentinel-2/MSI/L2A/2026/01/03/S2C_MSIL2A_20260103T103441_N0511_R108_T32UNB_20260103T142711.SAFE/GRANULE/L2A_T32UNB_A006942_20260103T103622/IMG_DATA/R10m/T32UNB_20260103T103441_B04_10m.jp2";
-const B08_URL: &str = "/vsis3/eodata/Sentinel-2/MSI/L2A/2026/01/03/S2C_MSIL2A_20260103T103441_N0511_R108_T32UNC_20260103T142711.SAFE/GRANULE/L2A_T32UNC_A006942_20260103T103622/IMG_DATA/R10m/T32UNC_20260103T103441_B08_10m.jp2";
-const SCL_URL: &str = "/vsis3/eodata/Sentinel-2/MSI/L2A/2026/01/03/S2C_MSIL2A_20260103T103441_N0511_R108_T32UNA_20260103T142711.SAFE/GRANULE/L2A_T32UNA_A006942_20260103T103622/IMG_DATA/R20m/T32UNA_20260103T103441_SCL_20m.jp2";
+const B04_URL: &str = "s3://eodata/Sentinel-2/MSI/L2A/2026/01/03/S2C_MSIL2A_20260103T103441_N0511_R108_T32UNB_20260103T142711.SAFE/GRANULE/L2A_T32UNB_A006942_20260103T103622/IMG_DATA/R10m/T32UNB_20260103T103441_B04_10m.jp2";
+const B08_URL: &str = "s3://eodata/Sentinel-2/MSI/L2A/2026/01/03/S2C_MSIL2A_20260103T103441_N0511_R108_T32UNC_20260103T142711.SAFE/GRANULE/L2A_T32UNC_A006942_20260103T103622/IMG_DATA/R10m/T32UNC_20260103T103441_B08_10m.jp2";
+const SCL_URL: &str = "s3://eodata/Sentinel-2/MSI/L2A/2026/01/03/S2C_MSIL2A_20260103T103441_N0511_R108_T32UNA_20260103T142711.SAFE/GRANULE/L2A_T32UNA_A006942_20260103T103622/IMG_DATA/R20m/T32UNA_20260103T103441_SCL_20m.jp2";
+
+/// Wraps an `s3://` URL in GDAL's `/vsis3/` virtual file system handler.
+/// The prefix is only added when the dataset is actually opened.
+fn vsis3(url: &str) -> String {
+    format!("/vsis3/{}", url.strip_prefix("s3://").unwrap_or(url))
+}
 
 struct BandData {
     b04: Vec<u16>,
@@ -165,9 +171,9 @@ fn read_bands(
         ReadStrategy::TiledReusedDataset { tile_size }
         | ReadStrategy::TiledReopenDataset { tile_size } => {
             let reopen_per_tile = matches!(strategy, ReadStrategy::TiledReopenDataset { .. });
-            let scl_dataset = gdal_open_dataset(std::path::Path::new(SCL_URL))?;
-            let b08_dataset = gdal_open_dataset(std::path::Path::new(B08_URL))?;
-            let b04_dataset = gdal_open_dataset(std::path::Path::new(B04_URL))?;
+            let scl_dataset = gdal_open_dataset(std::path::Path::new(&vsis3(SCL_URL)))?;
+            let b08_dataset = gdal_open_dataset(std::path::Path::new(&vsis3(B08_URL)))?;
+            let b04_dataset = gdal_open_dataset(std::path::Path::new(&vsis3(B04_URL)))?;
             read_bands_tiled_internal(
                 &b04_dataset,
                 &b08_dataset,
@@ -194,9 +200,9 @@ fn read_bands_full_raster(
 ) -> Result<(BandData, Duration), Box<dyn std::error::Error>> {
     let start = Instant::now();
 
-    let scl_dataset = gdal_open_dataset(std::path::Path::new(SCL_URL))?;
-    let b08_dataset = gdal_open_dataset(std::path::Path::new(B08_URL))?;
-    let b04_dataset = gdal_open_dataset(std::path::Path::new(B04_URL))?;
+    let scl_dataset = gdal_open_dataset(std::path::Path::new(&vsis3(SCL_URL)))?;
+    let b08_dataset = gdal_open_dataset(std::path::Path::new(&vsis3(B08_URL)))?;
+    let b04_dataset = gdal_open_dataset(std::path::Path::new(&vsis3(B04_URL)))?;
 
     // Read B04 (10m resolution)
     let b04_band = b04_dataset.rasterband(1)?;
@@ -265,9 +271,9 @@ fn read_bands_tiled_internal(
             // Get datasets for this tile (reopen if needed)
             let (b04_ds, b08_ds, scl_ds);
             let (b04_band, b08_band, scl_band) = if reopen_per_tile {
-                b04_ds = gdal_open_dataset(std::path::Path::new(B04_URL))?;
-                b08_ds = gdal_open_dataset(std::path::Path::new(B08_URL))?;
-                scl_ds = gdal_open_dataset(std::path::Path::new(SCL_URL))?;
+                b04_ds = gdal_open_dataset(std::path::Path::new(&vsis3(B04_URL)))?;
+                b08_ds = gdal_open_dataset(std::path::Path::new(&vsis3(B08_URL)))?;
+                scl_ds = gdal_open_dataset(std::path::Path::new(&vsis3(SCL_URL)))?;
                 (
                     b04_ds.rasterband(1)?,
                     b08_ds.rasterband(1)?,

--- a/geoengine/services/src/api/handlers/datasets.rs
+++ b/geoengine/services/src/api/handlers/datasets.rs
@@ -275,8 +275,9 @@ fn validate_tile(
     data_path_file_path: &Path,
     dataset_descriptor: &RasterResultDescriptor,
 ) -> Result<(), AddDatasetTilesError> {
-    // External data uses GDAL virtual filesystem paths (e.g., /vsicurl/, /vsis3/)
-    // and must not refer to local filesystem paths
+    // External data uses remote URLs (http://, https://, s3://) and must not
+    // refer to local filesystem paths. The GDAL virtual file system prefix is
+    // added only when the dataset is opened.
     if matches!(data_path, DataPath::External) {
         if data_path
             .validate_file_path(&tile.params.file_path)
@@ -3749,7 +3750,8 @@ mod tests {
         Ok(())
     }
 
-    /// Registers tile files on a mock HTTP server and creates tiles with `/vsicurl/` paths.
+    /// Registers tile files on a mock HTTP server and creates tiles with plain `http://` URLs.
+    /// The `/vsicurl/` prefix is only added when GDAL opens the dataset.
     /// The mock server serves the actual test data files so GDAL can read them via `/vsicurl/`.
     fn create_ndvi_tiles_vsicurl(server: &Server) -> Vec<AddDatasetTile> {
         let mut tiles = create_ndvi_tiles();
@@ -3790,9 +3792,8 @@ mod tests {
                     ),
             );
 
-            // Convert to a /vsicurl/ URL that passes validate_file_path
-            let url = server.url_str(&format!("/{file_path_str}"));
-            tile.params.file_path = format!("/vsicurl/{url}").into();
+            // Store the plain http URL — the /vsicurl/ prefix is added when opening the dataset
+            tile.params.file_path = server.url_str(&format!("/{file_path_str}")).into();
         }
 
         tiles
@@ -3804,7 +3805,7 @@ mod tests {
         // Start a mock HTTP server that serves the tile files (GDAL reads them via /vsicurl/)
         let mock_server = httptest::Server::run();
 
-        // Create tiles with /vsicurl/ paths backed by the mock server.
+        // Create tiles with plain http URLs backed by the mock server.
         // The mock server is kept alive for the full test duration (including the WMS query).
         let tiles = create_ndvi_tiles_vsicurl(&mock_server);
 
@@ -3851,7 +3852,7 @@ mod tests {
         assert!(db.load_dataset(&dataset_id).await.is_ok());
 
         // Add tiles through the API handler — validate_tile now checks that the paths
-        // are valid /vsicurl/ URLs (which they are), so this succeeds.
+        // are valid http URLs (which they are), so this succeeds.
         let req = actix_web::test::TestRequest::post()
             .uri(&format!("/dataset/{dataset_name}/tiles"))
             .append_header((header::CONTENT_LENGTH, 0))

--- a/geoengine/services/src/api/handlers/datasets.rs
+++ b/geoengine/services/src/api/handlers/datasets.rs
@@ -278,7 +278,10 @@ fn validate_tile(
     // External data uses GDAL virtual filesystem paths (e.g., /vsicurl/, /vsis3/)
     // and must not refer to local filesystem paths
     if matches!(data_path, DataPath::External) {
-        if data_path.validate_file_path(&tile.params.file_path).is_err() {
+        if data_path
+            .validate_file_path(&tile.params.file_path)
+            .is_err()
+        {
             return Err(AddDatasetTilesError::TileFileMustBeExternalPath {
                 file_path: tile.params.file_path.to_string_lossy().to_string(),
             });

--- a/geoengine/services/src/api/handlers/datasets.rs
+++ b/geoengine/services/src/api/handlers/datasets.rs
@@ -3792,7 +3792,7 @@ mod tests {
 
             // Convert to a /vsicurl/ URL that passes validate_file_path
             let url = server.url_str(&format!("/{file_path_str}"));
-            tile.params.file_path = format!("/vsicurl{url}").into();
+            tile.params.file_path = format!("/vsicurl/{url}").into();
         }
 
         tiles

--- a/geoengine/services/src/api/handlers/datasets.rs
+++ b/geoengine/services/src/api/handlers/datasets.rs
@@ -1726,6 +1726,7 @@ mod tests {
             test::raster_tile_from_file,
         },
     };
+    use httptest::{Expectation, Server, all_of, matchers::request, responders::status_code};
     use serde_json::{Value, json};
     use tokio_postgres::NoTls;
     use uuid::Uuid;
@@ -3748,25 +3749,65 @@ mod tests {
         Ok(())
     }
 
-    /// Creates NDVI tiles with absolute file paths, suitable for use with `DataPath::External`
-    /// (where paths are not resolved against any base path).
-    fn create_ndvi_tiles_absolute() -> Vec<AddDatasetTile> {
+    /// Registers tile files on a mock HTTP server and creates tiles with `/vsicurl/` paths.
+    /// The mock server serves the actual test data files so GDAL can read them via `/vsicurl/`.
+    fn create_ndvi_tiles_vsicurl(server: &Server) -> Vec<AddDatasetTile> {
         let mut tiles = create_ndvi_tiles();
-        let test_data_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .canonicalize()
-            .expect("should resolve during testing")
-            .parent()
-            .expect("should have parent")
-            .join("test_data/");
+
         for tile in &mut tiles {
-            tile.params.file_path = test_data_root.join(&tile.params.file_path);
+            let file_path_str = tile.params.file_path.to_string_lossy().to_string();
+
+            // Read the actual tile file from the test data directory
+            let local_path: PathBuf = test_data!(&file_path_str).into();
+            let data = std::fs::read(&local_path).unwrap();
+            let content_length = data.len();
+
+            let server_path = format!("/{file_path_str}");
+
+            // HEAD request (GDAL uses this to discover file size)
+            server.expect(
+                Expectation::matching(all_of![
+                    request::method("HEAD"),
+                    request::path(server_path.clone())
+                ])
+                .times(0..)
+                .respond_with(
+                    status_code(200)
+                        .append_header("Content-Length", content_length.to_string())
+                        .append_header("Accept-Ranges", "bytes"),
+                ),
+            );
+
+            // GET request (GDAL fetches tile data via /vsicurl/)
+            server.expect(
+                Expectation::matching(all_of![request::method("GET"), request::path(server_path)])
+                    .times(0..)
+                    .respond_with(
+                        status_code(200)
+                            .append_header("Content-Type", "image/tiff")
+                            .append_header("Content-Length", content_length.to_string())
+                            .body(data),
+                    ),
+            );
+
+            // Convert to a /vsicurl/ URL that passes validate_file_path
+            let url = server.url_str(&format!("/{file_path_str}"));
+            tile.params.file_path = format!("/vsicurl{url}").into();
         }
+
         tiles
     }
 
     #[ge_context::test]
     #[allow(clippy::too_many_lines)]
     async fn it_adds_tiles_to_external_dataset(app_ctx: PostgresContext<NoTls>) -> Result<()> {
+        // Start a mock HTTP server that serves the tile files (GDAL reads them via /vsicurl/)
+        let mock_server = httptest::Server::run();
+
+        // Create tiles with /vsicurl/ paths backed by the mock server.
+        // The mock server is kept alive for the full test duration (including the WMS query).
+        let tiles = create_ndvi_tiles_vsicurl(&mock_server);
+
         // add data
         let create = CreateDataset {
             data_path: DataPath::External,
@@ -3809,11 +3850,18 @@ mod tests {
 
         assert!(db.load_dataset(&dataset_id).await.is_ok());
 
-        // add tiles with absolute file paths directly via the database,
-        // bypassing the API handler's validate_tile check (which rejects local paths for External).
-        // The external data loading path is still exercised when tiles are queried.
-        let tiles = create_ndvi_tiles_absolute();
-        db.add_dataset_tiles(dataset_id, tiles).await?;
+        // Add tiles through the API handler — validate_tile now checks that the paths
+        // are valid /vsicurl/ URLs (which they are), so this succeeds.
+        let req = actix_web::test::TestRequest::post()
+            .uri(&format!("/dataset/{dataset_name}/tiles"))
+            .append_header((header::CONTENT_LENGTH, 0))
+            .append_header((header::AUTHORIZATION, Bearer::new(session.id().to_string())))
+            .append_header((header::CONTENT_TYPE, "application/json"))
+            .set_payload(serde_json::to_string(&tiles)?);
+
+        let res = send_test_request(req, app_ctx.clone()).await;
+
+        assert_eq!(res.status(), 200, "response: {res:?}");
 
         // create workflow
         let workflow = Workflow::Legacy {

--- a/geoengine/services/src/api/handlers/datasets.rs
+++ b/geoengine/services/src/api/handlers/datasets.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::{
     api::model::{
         datatypes::SpatialPartition2D,
@@ -249,16 +251,15 @@ pub async fn add_dataset_tiles_handler<C: ApplicationContext>(
 
     let tiles = tiles.into_inner();
 
-    let data_path_file_path = file_path_from_data_path(
-        &dataset
-            .data_path
-            .ok_or(AddDatasetTilesError::DatasetIsMissingDataPath)?,
-        &session_context,
-    )
-    .context(CannotAddTilesToDataset)?;
+    let data_path = dataset
+        .data_path
+        .ok_or(AddDatasetTilesError::DatasetIsMissingDataPath)?;
+
+    let data_path_file_path =
+        file_path_from_data_path(&data_path, &session_context).context(CannotAddTilesToDataset)?;
 
     for tile in &tiles {
-        validate_tile(tile, &data_path_file_path, &dataset_descriptor)?;
+        validate_tile(tile, &data_path, &data_path_file_path, &dataset_descriptor)?;
     }
 
     db.add_dataset_tiles(dataset_id, tiles)
@@ -270,27 +271,22 @@ pub async fn add_dataset_tiles_handler<C: ApplicationContext>(
 
 fn validate_tile(
     tile: &AddDatasetTile,
+    data_path: &DataPath,
     data_path_file_path: &Path,
     dataset_descriptor: &RasterResultDescriptor,
 ) -> Result<(), AddDatasetTilesError> {
-    if tile
-        .params
-        .file_path
-        .to_string_lossy()
-        .starts_with("/vsicurl")
-        || tile
-            .params
-            .file_path
-            .to_string_lossy()
-            .starts_with("/vsis3")
-    {
-        // do not validate remote files
-        // TODO: add flag to do this?
-        // TODO: detect remote files based on volume not file path?
-        // TODO: validate based on metadata, without opening the file
+    // External data uses GDAL virtual filesystem paths (e.g., /vsicurl/, /vsis3/)
+    // and must not refer to local filesystem paths
+    if matches!(data_path, DataPath::External) {
+        if data_path.validate_file_path(&tile.params.file_path).is_err() {
+            return Err(AddDatasetTilesError::TileFileMustBeExternalPath {
+                file_path: tile.params.file_path.to_string_lossy().to_string(),
+            });
+        }
         return Ok(());
     }
 
+    // Volume and upload paths must be relative; they are resolved against the data path
     ensure!(
         tile.params.file_path.is_relative(),
         TileFilePathNotRelative {
@@ -389,6 +385,7 @@ fn file_path_from_data_path<T: SessionContext>(
             })?
             .into(),
         DataPath::Upload(upload_id) => upload_id.root_path()?,
+        DataPath::External => PathBuf::new(),
     })
 }
 
@@ -954,7 +951,7 @@ pub async fn suggest_meta_data_handler<C: ApplicationContext>(
 
             let root_path = upload.id.root_path()?;
 
-            (root_path, main_file)
+            (Some(root_path), main_file)
         }
         DataPath::Volume(volume) => {
             let main_file = suggest
@@ -969,13 +966,31 @@ pub async fn suggest_meta_data_handler<C: ApplicationContext>(
                 },
             )?;
 
-            (root_path.path.clone(), main_file)
+            (Some(root_path.path.clone()), main_file)
+        }
+        DataPath::External => {
+            let main_file = suggest
+                .main_file
+                .ok_or(error::Error::NoMainFileCandidateFound)?;
+
+            // Validate that the file path is a valid external path (GDAL VSI path)
+            DataPath::External
+                .validate_file_path(Path::new(&main_file))
+                .map_err(|_| error::Error::InvalidPath)?;
+
+            // For external data, the file path is already absolute; no root path to resolve against
+            (None, main_file)
         }
     };
 
     let layer_name = suggest.layer_name;
 
-    let main_file_path = path_with_base_path(&root_path, Path::new(&main_file))?;
+    let main_file_path = if let Some(ref root_path) = root_path {
+        path_with_base_path(root_path, Path::new(&main_file))?
+    } else {
+        // For external data, the file path is already absolute
+        Path::new(&main_file).to_path_buf()
+    };
 
     let dataset = gdal_open_dataset(&main_file_path)?;
 
@@ -994,8 +1009,10 @@ pub async fn suggest_meta_data_handler<C: ApplicationContext>(
     } else {
         let mut gdal_params =
             gdal_parameters_from_dataset(&dataset, 1, &main_file_path, None, None)?;
-        if let Ok(relative_path) = gdal_params.file_path.strip_prefix(root_path) {
-            gdal_params.file_path = relative_path.to_path_buf();
+        if let Some(ref root_path) = root_path {
+            if let Ok(relative_path) = gdal_params.file_path.strip_prefix(root_path) {
+                gdal_params.file_path = relative_path.to_path_buf();
+            }
         }
         let result_descriptor = raster_descriptor_from_dataset(&dataset, 1)?;
 
@@ -1554,6 +1571,10 @@ async fn create_dataset_handler<C: ApplicationContext>(
             data_path: DataPath::Upload(volume),
             definition,
         } => create_upload_dataset(session, app_ctx, volume, definition).await,
+        CreateDataset {
+            data_path: DataPath::External,
+            definition,
+        } => create_external_dataset(session, app_ctx, definition).await,
     }
 }
 
@@ -1579,6 +1600,39 @@ async fn create_system_dataset<C: ApplicationContext>(
             definition.properties.into(),
             definition.meta_data.into(),
             Some(DataPath::Volume(volume_name)),
+        )
+        .await
+        .context(CannotCreateDataset)?;
+
+    db.add_permission(
+        Role::registered_user_role_id(),
+        dataset.id,
+        Permission::Read,
+    )
+    .await
+    .boxed_context(crate::error::PermissionDb)
+    .context(DatabaseAccess)?;
+
+    db.add_permission(Role::anonymous_role_id(), dataset.id, Permission::Read)
+        .await
+        .boxed_context(crate::error::PermissionDb)
+        .context(DatabaseAccess)?;
+
+    Ok(web::Json(dataset.name.into()))
+}
+
+async fn create_external_dataset<C: ApplicationContext>(
+    session: C::Session,
+    app_ctx: web::Data<C>,
+    definition: DatasetDefinition,
+) -> Result<web::Json<DatasetNameResponse>, CreateDatasetError> {
+    let db = app_ctx.session_context(session).db();
+
+    let dataset = db
+        .add_dataset(
+            definition.properties.into(),
+            definition.meta_data.into(),
+            Some(DataPath::External),
         )
         .await
         .context(CannotCreateDataset)?;
@@ -2078,6 +2132,60 @@ mod tests {
             .append_header((header::AUTHORIZATION, Bearer::new(session.id().to_string())))
             .append_header((header::CONTENT_TYPE, "application/json"))
             .set_payload(serde_json::to_string(&create)?);
+
+        let res = send_test_request(req, app_ctx.clone()).await;
+        assert_eq!(res.status(), 200);
+
+        Ok(())
+    }
+
+    #[ge_context::test]
+    async fn it_creates_external_gdal_dataset(app_ctx: PostgresContext<NoTls>) -> Result<()> {
+        let session = app_ctx.create_anonymous_session().await.unwrap();
+
+        let mut meta_data = create_ndvi_meta_data();
+
+        // For external data, the file path is already absolute; no resolution against a volume
+        meta_data.params.file_path =
+            test_data!("raster/modis_ndvi/MOD13A2_M_NDVI_%_START_TIME_%.TIFF").to_path_buf();
+
+        let create = CreateDataset {
+            data_path: DataPath::External,
+            definition: DatasetDefinition {
+                properties: AddDataset {
+                    name: None,
+                    display_name: "ndvi external".to_string(),
+                    description: "ndvi".to_string(),
+                    source_operator: "GdalSource".to_string(),
+                    symbology: None,
+                    provenance: None,
+                    tags: Some(vec!["upload".to_owned(), "test".to_owned()]),
+                },
+                meta_data: MetaDataDefinition::GdalMetaDataRegular(meta_data.into()),
+            },
+        };
+
+        // create via admin session
+        let admin_session = admin_login(&app_ctx).await;
+        let req = actix_web::test::TestRequest::post()
+            .uri("/dataset")
+            .append_header((header::CONTENT_LENGTH, 0))
+            .append_header((
+                header::AUTHORIZATION,
+                Bearer::new(admin_session.id().to_string()),
+            ))
+            .append_header((header::CONTENT_TYPE, "application/json"))
+            .set_json(create);
+        let res = send_test_request(req, app_ctx.clone()).await;
+        assert_eq!(res.status(), 200);
+
+        let DatasetNameResponse { dataset_name } = actix_web::test::read_body_json(res).await;
+
+        // assert dataset is accessible via regular session
+        let req = actix_web::test::TestRequest::get()
+            .uri(&format!("/dataset/{dataset_name}"))
+            .append_header((header::CONTENT_LENGTH, 0))
+            .append_header((header::AUTHORIZATION, Bearer::new(session.id().to_string())));
 
         let res = send_test_request(req, app_ctx.clone()).await;
         assert_eq!(res.status(), 200);
@@ -3631,6 +3739,141 @@ mod tests {
         let image_bytes = actix_web::test::read_body(res).await;
 
         // geoengine_datatypes::util::test::save_test_bytes(&image_bytes, "wms.png");
+
+        assert_image_equals(test_data!("raster/multi_tile/wms.png"), &image_bytes);
+
+        Ok(())
+    }
+
+    /// Creates NDVI tiles with absolute file paths, suitable for use with `DataPath::External`
+    /// (where paths are not resolved against any base path).
+    fn create_ndvi_tiles_absolute() -> Vec<AddDatasetTile> {
+        let mut tiles = create_ndvi_tiles();
+        let test_data_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .canonicalize()
+            .expect("should resolve during testing")
+            .parent()
+            .expect("should have parent")
+            .join("test_data/");
+        for tile in &mut tiles {
+            tile.params.file_path = test_data_root.join(&tile.params.file_path);
+        }
+        tiles
+    }
+
+    #[ge_context::test]
+    #[allow(clippy::too_many_lines)]
+    async fn it_adds_tiles_to_external_dataset(app_ctx: PostgresContext<NoTls>) -> Result<()> {
+        // add data
+        let create = CreateDataset {
+            data_path: DataPath::External,
+            definition: DatasetDefinition {
+                properties: AddDataset {
+                    name: None,
+                    display_name: "ndvi external (tiled)".to_string(),
+                    description: "ndvi".to_string(),
+                    source_operator: "MultiBandGdalSource".to_string(),
+                    symbology: None,
+                    provenance: None,
+                    tags: Some(vec!["upload".to_owned(), "test".to_owned()]),
+                },
+                meta_data: MetaDataDefinition::GdalMultiBand(GdalMultiBand {
+                    r#type: Default::default(),
+                    result_descriptor: create_ndvi_result_descriptor(true).into(),
+                }),
+            },
+        };
+
+        let session = admin_login(&app_ctx).await;
+        let ctx = app_ctx.session_context(session.clone());
+
+        let db = ctx.db();
+
+        let req = actix_web::test::TestRequest::post()
+            .uri("/dataset")
+            .append_header((header::CONTENT_LENGTH, 0))
+            .append_header((header::AUTHORIZATION, Bearer::new(session.id().to_string())))
+            .append_header((header::CONTENT_TYPE, "application/json"))
+            .set_payload(serde_json::to_string(&create)?);
+        let res = send_test_request(req, app_ctx.clone()).await;
+
+        let DatasetNameResponse { dataset_name } = actix_web::test::read_body_json(res).await;
+        let dataset_id = db
+            .resolve_dataset_name_to_id(&dataset_name)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(db.load_dataset(&dataset_id).await.is_ok());
+
+        // add tiles with absolute file paths directly via the database,
+        // bypassing the API handler's validate_tile check (which rejects local paths for External).
+        // The external data loading path is still exercised when tiles are queried.
+        let tiles = create_ndvi_tiles_absolute();
+        db.add_dataset_tiles(dataset_id, tiles).await?;
+
+        // create workflow
+        let workflow = Workflow::Legacy {
+            operator: geoengine_operators::engine::TypedOperator::Raster(
+                MultiBandGdalSource {
+                    params: MultiBandGdalSourceParameters::new(dataset_name.into()),
+                }
+                .boxed(),
+            ),
+        };
+
+        let id = ctx.db().register_workflow(workflow.clone()).await.unwrap();
+
+        let colorizer = geoengine_datatypes::operations::image::Colorizer::linear_gradient(
+            vec![
+                (0.0, RgbaColor::white()).try_into().unwrap(),
+                (255.0, RgbaColor::black()).try_into().unwrap(),
+            ],
+            RgbaColor::transparent(),
+            RgbaColor::white(),
+            RgbaColor::black(),
+        )
+        .unwrap();
+
+        let raster_colorizer =
+            crate::api::model::datatypes::RasterColorizer::SingleBand(SingleBandRasterColorizer {
+                r#type: Default::default(),
+                band: 0,
+                band_colorizer: colorizer.into(),
+            });
+
+        let params = &[
+            ("request", "GetMap"),
+            ("service", "WMS"),
+            ("version", "1.3.0"),
+            ("layers", &id.to_string()),
+            ("bbox", "-90,-180,90,180"),
+            ("width", "3600"),
+            ("height", "1800"),
+            ("crs", "EPSG:4326"),
+            (
+                "styles",
+                &format!(
+                    "custom:{}",
+                    serde_json::to_string(&raster_colorizer).unwrap()
+                ),
+            ),
+            ("format", "image/png"),
+            ("time", "2014-01-01T00:00:00.0Z"),
+        ];
+
+        let req = actix_web::test::TestRequest::get()
+            .uri(&format!(
+                "/wms/{}?{}",
+                id,
+                serde_urlencoded::to_string(params).unwrap()
+            ))
+            .append_header((header::AUTHORIZATION, Bearer::new(session.id().to_string())));
+        let res = send_test_request(req, app_ctx).await;
+
+        assert_eq!(res.status(), 200);
+
+        let image_bytes = actix_web::test::read_body(res).await;
 
         assert_image_equals(test_data!("raster/multi_tile/wms.png"), &image_bytes);
 

--- a/geoengine/services/src/api/model/responses/datasets/errors.rs
+++ b/geoengine/services/src/api/model/responses/datasets/errors.rs
@@ -128,6 +128,9 @@ pub enum AddDatasetTilesError {
     TileFilePathNotRelative {
         file_path: String,
     },
+    TileFileMustBeExternalPath {
+        file_path: String,
+    },
     CannotOpenTileFile {
         source: geoengine_operators::error::Error,
         file_path: String,

--- a/geoengine/services/src/api/model/services.rs
+++ b/geoengine/services/src/api/model/services.rs
@@ -12,7 +12,8 @@ use crate::api::model::operators::{
 use crate::datasets::DatasetName;
 use crate::datasets::external::{GdalRetries, WildliveDataConnectorAuth};
 use crate::datasets::storage::validate_tags;
-use crate::datasets::upload::{UploadId, VolumeName};
+use crate::datasets::upload::{UploadId, UploadRootPath, VolumeName, Volumes};
+use crate::error::{Error, Result};
 use crate::projects::Symbology;
 use crate::util::Secret;
 use crate::util::oidc::RefreshToken;
@@ -21,7 +22,7 @@ use geoengine_datatypes::primitives::DateTime;
 use geoengine_datatypes::util::test::TestDefault;
 use geoengine_macros::type_tag;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use url::Url;
 use utoipa::ToSchema;
 use validator::{Validate, ValidationErrors};
@@ -167,11 +168,45 @@ pub enum DataPath {
     Volume(VolumeName),
     #[schema(title = "DataPathUpload")]
     Upload(UploadId),
+    #[schema(title = "DataPathExternal")]
+    External,
 }
 
 impl TestDefault for DataPath {
     fn test_default() -> Self {
         DataPath::Volume(VolumeName("test_data".to_string()))
+    }
+}
+
+impl DataPath {
+    /// Resolves the data path to its base directory path.
+    /// Returns `Ok(None)` for external data (no base path needed).
+    /// Returns `Ok(Some(path))` for volume and upload data.
+    pub fn resolve_base_path(&self) -> Result<Option<PathBuf>> {
+        match self {
+            DataPath::Volume(volume_name) => {
+                let volumes = Volumes::default();
+                let volume = volumes
+                    .volumes
+                    .iter()
+                    .find(|v| v.name == *volume_name)
+                    .ok_or_else(|| Error::UnknownVolumeName {
+                        volume_name: volume_name.0.clone(),
+                    })?;
+                Ok(Some(volume.path.clone()))
+            }
+            DataPath::Upload(upload_id) => Ok(Some(upload_id.root_path()?)),
+            DataPath::External => Ok(None),
+        }
+    }
+
+    /// Resolves a file path relative to the data path into an absolute file path.
+    /// For external data, the file path is treated as already absolute.
+    pub fn resolve_file_path(&self, file_path: &Path) -> Result<PathBuf> {
+        match self.resolve_base_path()? {
+            Some(base_path) => Ok(base_path.join(file_path)),
+            None => Ok(file_path.to_path_buf()),
+        }
     }
 }
 

--- a/geoengine/services/src/api/model/services.rs
+++ b/geoengine/services/src/api/model/services.rs
@@ -211,15 +211,19 @@ impl DataPath {
 
     /// Validates that a file path is appropriate for this data path variant.
     ///
-    /// For `External`, the file path must be a GDAL virtual filesystem path
-    /// (e.g., `/vsicurl/` or `/vsis3/`), not a local filesystem path.
+    /// For `External`, the file path must be a remote URL with an `http://`, `https://`,
+    /// or `s3://` scheme. The GDAL virtual file system prefix (e.g. `/vsicurl/` or
+    /// `/vsis3/`) is only added when the dataset is actually opened.
     /// For `Volume` and `Upload`, the file path must be a relative path
     /// with no root, parent, or current-directory components.
     pub fn validate_file_path(&self, file_path: &Path) -> Result<()> {
         match self {
             DataPath::External => {
                 let path_str = file_path.to_string_lossy();
-                if !path_str.starts_with("/vsicurl/") && !path_str.starts_with("/vsis3/") {
+                let is_url = path_str.starts_with("http://")
+                    || path_str.starts_with("https://")
+                    || path_str.starts_with("s3://");
+                if !is_url {
                     return Err(Error::InvalidPath);
                 }
                 Ok(())

--- a/geoengine/services/src/api/model/services.rs
+++ b/geoengine/services/src/api/model/services.rs
@@ -161,6 +161,10 @@ pub struct CreateDataset {
     pub definition: DatasetDefinition,
 }
 
+/// A data path is a reference to a location where data is stored.
+/// It can be a volume, an upload, or an external source.
+/// This information is used when turning a relative file path of a `Dataset` file
+/// into an absolute file path on the server.
 #[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum DataPath {

--- a/geoengine/services/src/api/model/services.rs
+++ b/geoengine/services/src/api/model/services.rs
@@ -208,6 +208,31 @@ impl DataPath {
             None => Ok(file_path.to_path_buf()),
         }
     }
+
+    /// Validates that a file path is appropriate for this data path variant.
+    ///
+    /// For `External`, the file path must be a GDAL virtual filesystem path
+    /// (e.g., `/vsicurl/` or `/vsis3/`), not a local filesystem path.
+    /// For `Volume` and `Upload`, the file path must be a relative path
+    /// with no root, parent, or current-directory components.
+    pub fn validate_file_path(&self, file_path: &Path) -> Result<()> {
+        match self {
+            DataPath::External => {
+                let path_str = file_path.to_string_lossy();
+                if !path_str.starts_with("/vsicurl/") && !path_str.starts_with("/vsis3/") {
+                    return Err(Error::InvalidPath);
+                }
+                Ok(())
+            }
+            DataPath::Volume(_) | DataPath::Upload(_) => {
+                let _file_name = file_path.file_name().ok_or(Error::PathIsNotAFile)?;
+
+                crate::util::validate_relative_path(Path::new(""), file_path)?;
+
+                Ok(())
+            }
+        }
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, ToSchema, Validate)]

--- a/geoengine/services/src/cli/stac_import.rs
+++ b/geoengine/services/src/cli/stac_import.rs
@@ -3,7 +3,7 @@
 use ordered_float::OrderedFloat;
 use std::{
     collections::{HashMap, HashSet},
-    path::PathBuf,
+    path::{Path, PathBuf},
     str::FromStr,
     time::{Duration, Instant},
 };
@@ -1622,7 +1622,7 @@ impl AssetBandProcessor<'_> {
             band: band_index as u32,
             z_index: self.z_index,
             params: GdalDatasetParameters {
-                file_path: file_path.into(),
+                file_path,
                 rasterband_channel: band_idx + 1, // gdal channels are 1-based
                 geo_transform: self.geo_transform.into(),
                 width,
@@ -1641,9 +1641,9 @@ impl AssetBandProcessor<'_> {
 
     fn gdal_options_for_file_path(
         &self,
-        file_path: &GdalFilePath,
+        file_path: &Path,
     ) -> Result<Option<Vec<GdalConfigOption>>, anyhow::Error> {
-        let gdal_open_options = if let GdalFilePath::S3(_) = *file_path {
+        let gdal_open_options = if file_path.to_string_lossy().starts_with("s3://") {
             // TODO: allow skipping s3 assets on missing credentials?
             let s3_endpoint = self.params.s3_endpoint.as_ref().ok_or(anyhow::anyhow!(
                 "S3 endpoint must be provided for S3 assets"
@@ -1733,7 +1733,7 @@ impl AssetBandProcessor<'_> {
             band: band_index as u32,
             z_index: self.z_index,
             params: GdalDatasetParameters {
-                file_path: file_path.into(),
+                file_path,
                 rasterband_channel: band_idx + 1, // gdal channels are 1-based
                 geo_transform: self.geo_transform.into(),
                 width,
@@ -1751,26 +1751,14 @@ impl AssetBandProcessor<'_> {
     }
 }
 
-fn gdal_file_path(asset: &Asset) -> anyhow::Result<GdalFilePath> {
-    if asset.href.starts_with("http") {
-        Ok(GdalFilePath::Http(format!("/vsicurl/{}", asset.href)))
-    } else if let Some(s3_url) = asset.href.strip_prefix("s3://") {
-        Ok(GdalFilePath::S3(format!("/vsis3/{s3_url}")))
+fn gdal_file_path(asset: &Asset) -> anyhow::Result<PathBuf> {
+    if asset.href.starts_with("http://")
+        || asset.href.starts_with("https://")
+        || asset.href.starts_with("s3://")
+    {
+        Ok(PathBuf::from(asset.href.clone()))
     } else {
         anyhow::bail!("Unsupported asset href format for GDAL: {}", asset.href);
-    }
-}
-
-enum GdalFilePath {
-    Http(String),
-    S3(String),
-}
-
-impl GdalFilePath {
-    fn into(self) -> PathBuf {
-        match self {
-            GdalFilePath::Http(path) | GdalFilePath::S3(path) => PathBuf::from(path),
-        }
     }
 }
 
@@ -2781,7 +2769,7 @@ mod tests {
         assert_eq!(
             tile.params.file_path,
             PathBuf::from(
-                "/vsicurl/https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MB/2026/1/S2B_32UMB_20260128_0_L2A/B02.tif"
+                "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MB/2026/1/S2B_32UMB_20260128_0_L2A/B02.tif"
             )
         );
 
@@ -2930,7 +2918,7 @@ mod tests {
         assert_eq!(tile.params.height, 10_980);
         assert_eq!(
             tile.params.file_path,
-            PathBuf::from("/vsis3/eodata/Sentinel-2/MSI/L2A/2026/01/28/example/B02_10m.jp2")
+            PathBuf::from("s3://eodata/Sentinel-2/MSI/L2A/2026/01/28/example/B02_10m.jp2")
         );
 
         let expected_z_index = chrono::DateTime::parse_from_rfc3339("2026-01-29T14:19:30Z")

--- a/geoengine/services/src/contexts/db_types.rs
+++ b/geoengine/services/src/contexts/db_types.rs
@@ -1421,6 +1421,7 @@ impl TryFrom<TypedDataProviderDefinitionDbType> for TypedDataProviderDefinition 
 pub struct DataPathDbType {
     pub volume_name: Option<String>,
     pub upload_id: Option<uuid::Uuid>,
+    pub external: Option<bool>,
 }
 
 impl From<&DataPath> for DataPathDbType {
@@ -1429,10 +1430,17 @@ impl From<&DataPath> for DataPathDbType {
             DataPath::Volume(volume_name) => Self {
                 volume_name: Some(volume_name.0.clone()),
                 upload_id: None,
+                external: Some(false),
             },
             DataPath::Upload(upload_id) => Self {
                 volume_name: None,
                 upload_id: Some(upload_id.0),
+                external: Some(false),
+            },
+            DataPath::External => Self {
+                volume_name: None,
+                upload_id: None,
+                external: Some(true),
             },
         }
     }
@@ -1441,9 +1449,10 @@ impl From<&DataPath> for DataPathDbType {
 impl TryFrom<DataPathDbType> for DataPath {
     type Error = Error;
     fn try_from(other: DataPathDbType) -> Result<Self, Error> {
-        match (other.volume_name, other.upload_id) {
-            (Some(v), None) => Ok(DataPath::Volume(VolumeName(v))),
-            (None, Some(u)) => Ok(DataPath::Upload(UploadId(u))),
+        match (other.volume_name, other.upload_id, other.external) {
+            (Some(v), None, _) => Ok(DataPath::Volume(VolumeName(v))),
+            (None, Some(u), _) => Ok(DataPath::Upload(UploadId(u))),
+            (None, None, Some(true)) => Ok(DataPath::External),
             _ => Err(Error::UnexpectedInvalidDbTypeConversion),
         }
     }

--- a/geoengine/services/src/contexts/migrations/current_schema.sql
+++ b/geoengine/services/src/contexts/migrations/current_schema.sql
@@ -642,9 +642,9 @@ CREATE TABLE workflows (
 -- TODO: add length constraints
 
 CREATE TYPE "DataPath" AS (
-    -- oneOf
     volume_name text,
-    upload_id uuid
+    upload_id uuid,
+    external boolean
 );
 
 CREATE TABLE datasets (

--- a/geoengine/services/src/contexts/migrations/migration_0028_stac_provider.sql
+++ b/geoengine/services/src/contexts/migrations/migration_0028_stac_provider.sql
@@ -34,3 +34,6 @@ CREATE TYPE "StacDataProviderDefinition" AS (
 
 ALTER TYPE "DataProviderDefinition" ADD ATTRIBUTE
 stac_data_provider_definition "StacDataProviderDefinition";
+
+-- Add explicit boolean for the External variant
+ALTER TYPE "DataPath" ADD ATTRIBUTE external boolean;

--- a/geoengine/services/src/datasets/external/sentinel_s2_l2a_cogs/mod.rs
+++ b/geoengine/services/src/datasets/external/sentinel_s2_l2a_cogs/mod.rs
@@ -611,7 +611,7 @@ impl SentinelS2L2aCogsMetaData {
         Ok(GdalLoadingInfoTemporalSlice {
             time: time_interval,
             params: Some(GdalDatasetParameters {
-                file_path: PathBuf::from(format!("/vsicurl/{}", asset.href)),
+                file_path: PathBuf::from(asset.href.clone()),
                 rasterband_channel: 1,
                 geo_transform: GdalDatasetGeoTransform::from(
                     asset
@@ -1011,7 +1011,7 @@ mod tests {
         let expected = vec![GdalLoadingInfoTemporalSlice {
             time: TimeInterval::new_unchecked(1_609_581_746_000, 1_609_581_758_000),
             params: Some(GdalDatasetParameters {
-                file_path: "/vsicurl/https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/R/PU/2021/1/S2B_32RPU_20210102_0_L2A/B01.tif".into(),
+                file_path: "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/R/PU/2021/1/S2B_32RPU_20210102_0_L2A/B01.tif".into(),
                 rasterband_channel: 1,
                 geo_transform: GdalDatasetGeoTransform {
                     origin_coordinate: (600_000.0, 3_400_020.0).into(),
@@ -1411,7 +1411,7 @@ mod tests {
             vec![GdalLoadingInfoTemporalSlice {
                 time: TimeInterval::new_unchecked(1_632_384_644_000,1_632_384_704_000),
                 params: Some(GdalDatasetParameters {
-                    file_path: "/vsicurl/https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/WC/2021/9/S2B_36MWC_20210923_0_L2A/B04.tif".into(),
+                    file_path: "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/WC/2021/9/S2B_36MWC_20210923_0_L2A/B04.tif".into(),
                     rasterband_channel: 1,
                     geo_transform: GdalDatasetGeoTransform {
                         origin_coordinate: (499_980.0,9_800_020.00).into(),

--- a/geoengine/services/src/datasets/external/stac/loading_info.rs
+++ b/geoengine/services/src/datasets/external/stac/loading_info.rs
@@ -586,8 +586,9 @@ impl StacMultiBandMetaData {
 
     fn gdal_config_options_for_file_path(&self, file_path: &Path) -> Option<Vec<(String, String)>> {
         let file_path_str = file_path.to_string_lossy();
-        let is_vsi_s3 = file_path_str.starts_with("/vsis3/");
-        let is_vsi_curl = file_path_str.starts_with("/vsicurl/");
+        let is_vsi_s3 = file_path_str.starts_with("s3://");
+        let is_vsi_curl =
+            file_path_str.starts_with("http://") || file_path_str.starts_with("https://");
 
         if !is_vsi_s3 && !is_vsi_curl {
             return None;
@@ -668,12 +669,11 @@ fn stac_query_time_interval(
 }
 
 fn gdal_file_path(href: &str) -> Option<PathBuf> {
-    if href.starts_with("http") {
-        return Some(PathBuf::from(format!("/vsicurl/{href}")));
+    if href.starts_with("http://") || href.starts_with("https://") || href.starts_with("s3://") {
+        return Some(PathBuf::from(href));
     }
 
-    href.strip_prefix("s3://")
-        .map(|s3_path| PathBuf::from(format!("/vsis3/{s3_path}")))
+    None
 }
 
 fn proj_shape_from_fields(fields: &serde_json::Map<String, Value>) -> Option<(usize, usize)> {
@@ -987,15 +987,15 @@ mod tests {
 
             for param in &b08_params {
                 assert!(
-                    param.file_path.to_string_lossy().contains("/vsis3/"),
-                    "B08 file should use S3 path: {:?}",
+                    param.file_path.to_string_lossy().starts_with("s3://"),
+                    "B08 file should use S3 URL: {:?}",
                     param.file_path
                 );
             }
             for param in &b04_params {
                 assert!(
-                    param.file_path.to_string_lossy().contains("/vsis3/"),
-                    "B04 file should use S3 path: {:?}",
+                    param.file_path.to_string_lossy().starts_with("s3://"),
+                    "B04 file should use S3 URL: {:?}",
                     param.file_path
                 );
             }

--- a/geoengine/services/src/datasets/postgres.rs
+++ b/geoengine/services/src/datasets/postgres.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use crate::api::handlers::datasets::AddDatasetTile;
 use crate::api::model::datatypes::SpatialPartition2D;
 use crate::api::model::services::{DataPath, UpdateDataset};
@@ -8,7 +6,7 @@ use crate::datasets::listing::Provenance;
 use crate::datasets::listing::{DatasetListOptions, DatasetListing, DatasetProvider};
 use crate::datasets::listing::{OrderBy, ProvenanceOutput};
 use crate::datasets::storage::{Dataset, DatasetDb, DatasetStore, MetaDataDefinition};
-use crate::datasets::upload::{FileId, UploadRootPath, Volumes};
+use crate::datasets::upload::FileId;
 use crate::datasets::upload::{Upload, UploadDb, UploadId};
 use crate::datasets::{AddDataset, DatasetIdAndName, DatasetName};
 use crate::error::{self, Error, Result};
@@ -691,31 +689,6 @@ where
 
         let data_path: DataPath = row.get(1);
 
-        let data_path =
-            match data_path {
-                DataPath::Volume(volume_name) =>
-                // TODO: after Volume management is implemented, this needs to be adapted
-                {
-                    Volumes::default()
-                        .volumes
-                        .iter()
-                        .find(|v| v.name == volume_name)
-                        .ok_or(Error::UnknownVolumeName {
-                            volume_name: volume_name.0.clone(),
-                        })
-                        .map_err(|e| geoengine_operators::error::Error::MetaData {
-                            source: Box::new(e),
-                        })?
-                        .path
-                        .clone()
-                }
-                DataPath::Upload(upload_id) => upload_id.root_path().map_err(|e| {
-                    geoengine_operators::error::Error::MetaData {
-                        source: Box::new(e),
-                    }
-                })?,
-            };
-
         Ok(Box::new(MultiBandGdalLoadingInfoProvider {
             dataset_id: id,
             result_descriptor,
@@ -735,7 +708,7 @@ where
 {
     dataset_id: DatasetId,
     result_descriptor: RasterResultDescriptor,
-    data_path: PathBuf,
+    data_path: DataPath,
     db: PostgresDb<Tls>,
 }
 
@@ -988,19 +961,27 @@ where
                     source: Box::new(e),
                 })?;
 
+            // Resolve the base path once before the tile loop to avoid repeated volume lookups
+            let base_path = self.data_path.resolve_base_path().map_err(|e| {
+                geoengine_operators::error::Error::MetaData {
+                    source: Box::new(e),
+                }
+            })?;
+
             let files: Vec<TileFile> = rows
                 .into_iter()
-                .map(|row| TileFile {
-                    spatial_partition: row.get(0),
-                    time: row.get(1),
-                    band: row.get(2),
-                    z_index: row.get(3),
-                    params: {
-                        let mut params: GdalDatasetParameters = row.get(4);
-                        // at some point we need to turn the relative file paths of tiles into absolute paths
-                        params.file_path = self.data_path.join(&params.file_path);
-                        params
-                    },
+                .map(|row| {
+                    let mut params: GdalDatasetParameters = row.get(4);
+                    if let Some(ref base_path) = base_path {
+                        params.file_path = base_path.join(&params.file_path);
+                    }
+                    TileFile {
+                        spatial_partition: row.get(0),
+                        time: row.get(1),
+                        band: row.get(2),
+                        z_index: row.get(3),
+                        params,
+                    }
                 })
                 .collect();
 

--- a/geoengine/services/src/datasets/upload.rs
+++ b/geoengine/services/src/datasets/upload.rs
@@ -145,18 +145,7 @@ impl AdjustFilePath for Upload {
         let file_name = file_path.file_name().ok_or(error::Error::PathIsNotAFile)?;
 
         // Reject absolute / remote paths — upload paths must be relative filenames
-        for component in file_path.components() {
-            if let std::path::Component::RootDir
-            | std::path::Component::Prefix(_)
-            | std::path::Component::CurDir
-            | std::path::Component::ParentDir = component
-            {
-                return Err(error::Error::PathMustNotContainParentReferences {
-                    base: self.id.root_path()?,
-                    sub_path: file_path.into(),
-                });
-            }
-        }
+        crate::util::validate_relative_path(&self.id.root_path()?, file_path)?;
 
         Ok(self.id.root_path()?.join(file_name))
     }

--- a/geoengine/services/src/datasets/upload.rs
+++ b/geoengine/services/src/datasets/upload.rs
@@ -144,6 +144,20 @@ impl AdjustFilePath for Upload {
     fn adjust_file_path(&self, file_path: &Path) -> Result<PathBuf> {
         let file_name = file_path.file_name().ok_or(error::Error::PathIsNotAFile)?;
 
+        // Reject absolute / remote paths — upload paths must be relative filenames
+        for component in file_path.components() {
+            if let std::path::Component::RootDir
+            | std::path::Component::Prefix(_)
+            | std::path::Component::CurDir
+            | std::path::Component::ParentDir = component
+            {
+                return Err(error::Error::PathMustNotContainParentReferences {
+                    base: self.id.root_path()?,
+                    sub_path: file_path.into(),
+                });
+            }
+        }
+
         Ok(self.id.root_path()?.join(file_name))
     }
 }
@@ -166,4 +180,101 @@ pub trait UploadDb {
     async fn load_upload(&self, upload: UploadId) -> Result<Upload>;
 
     async fn create_upload(&self, upload: Upload) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use geoengine_datatypes::util::Identifier;
+    use std::path::Path;
+
+    fn make_upload() -> Upload {
+        Upload {
+            id: UploadId::new(),
+            files: vec![],
+        }
+    }
+
+    #[test]
+    fn it_adjusts_upload_file_path() {
+        let upload = make_upload();
+        let result = upload.adjust_file_path(Path::new("test_file.tif"));
+        assert!(result.is_ok());
+
+        let path = result.unwrap();
+        assert_eq!(
+            path.file_name(),
+            Some(std::ffi::OsStr::new("test_file.tif"))
+        );
+        assert!(path.to_string_lossy().contains("test_upload"));
+    }
+
+    #[test]
+    fn it_adjusts_upload_file_path_with_subdirectory() {
+        let upload = make_upload();
+        let result = upload.adjust_file_path(Path::new("subdir/test_file.tif"));
+        assert!(result.is_ok());
+
+        // The file name is extracted from the path, subdirectory is ignored
+        let path = result.unwrap();
+        assert_eq!(
+            path.file_name(),
+            Some(std::ffi::OsStr::new("test_file.tif"))
+        );
+        // The path must be relative to the upload dir, not include the subdirectory
+        assert!(!path.to_string_lossy().contains("subdir"));
+    }
+
+    #[test]
+    fn it_rejects_upload_file_path_with_root_dir() {
+        let upload = make_upload();
+        let result = upload.adjust_file_path(Path::new("/etc/passwd"));
+        assert!(result.is_err());
+        assert!(
+            matches!(
+                result.unwrap_err(),
+                error::Error::PathMustNotContainParentReferences { .. }
+            ),
+            "expected PathMustNotContainParentReferences"
+        );
+    }
+
+    #[test]
+    fn it_rejects_upload_file_path_with_cur_dir() {
+        let upload = make_upload();
+        let result = upload.adjust_file_path(Path::new("./file.txt"));
+        assert!(result.is_err());
+        assert!(
+            matches!(
+                result.unwrap_err(),
+                error::Error::PathMustNotContainParentReferences { .. }
+            ),
+            "expected PathMustNotContainParentReferences"
+        );
+    }
+
+    #[test]
+    fn it_rejects_upload_file_path_with_parent_dir() {
+        let upload = make_upload();
+        let result = upload.adjust_file_path(Path::new("../file.txt"));
+        assert!(result.is_err());
+        assert!(
+            matches!(
+                result.unwrap_err(),
+                error::Error::PathMustNotContainParentReferences { .. }
+            ),
+            "expected PathMustNotContainParentReferences"
+        );
+    }
+
+    #[test]
+    fn it_rejects_upload_file_path_without_file_name() {
+        let upload = make_upload();
+        let result = upload.adjust_file_path(Path::new(""));
+        assert!(result.is_err());
+        assert!(
+            matches!(result.unwrap_err(), error::Error::PathIsNotAFile { .. }),
+            "expected PathIsNotAFile"
+        );
+    }
 }

--- a/geoengine/services/src/util/mod.rs
+++ b/geoengine/services/src/util/mod.rs
@@ -81,6 +81,25 @@ where
     }
 }
 
+/// Validates that a path is relative — no root, prefix, current-dir, or parent-dir components.
+pub fn validate_relative_path(base: &Path, sub_path: &Path) -> Result<()> {
+    for component in sub_path.components() {
+        if matches!(
+            component,
+            std::path::Component::CurDir
+                | std::path::Component::ParentDir
+                | std::path::Component::RootDir
+                | std::path::Component::Prefix(_)
+        ) {
+            return Err(Error::PathMustNotContainParentReferences {
+                base: base.into(),
+                sub_path: sub_path.into(),
+            });
+        }
+    }
+    Ok(())
+}
+
 /// Join `base` and `sub_path` and ensure the `sub_path` doesn't escape the `base`
 /// returns an error if the `sub_path` escapes the `base`
 ///
@@ -95,18 +114,7 @@ pub fn path_with_base_path(base: &Path, sub_path: &Path) -> Result<PathBuf> {
             });
         }
     }
-    for component in sub_path.components() {
-        if let std::path::Component::CurDir
-        | std::path::Component::ParentDir
-        | std::path::Component::RootDir
-        | std::path::Component::Prefix(_) = component
-        {
-            return Err(Error::PathMustNotContainParentReferences {
-                base: base.into(),
-                sub_path: sub_path.into(),
-            });
-        }
-    }
+    validate_relative_path(base, sub_path)?;
 
     let path = base.join(sub_path);
 

--- a/openapi.json
+++ b/openapi.json
@@ -6938,7 +6938,8 @@
               "external"
             ]
           }
-        ]
+        ],
+        "description": "A data path is a reference to a location where data is stored.\nIt can be a volume, an upload, or an external source.\nThis information is used when turning a relative file path of a `Dataset` file\ninto an absolute file path on the server."
       },
       "DataProviderId": {
         "type": "string",

--- a/openapi.json
+++ b/openapi.json
@@ -6930,6 +6930,13 @@
                 "$ref": "#/components/schemas/UploadId"
               }
             }
+          },
+          {
+            "type": "string",
+            "title": "DataPathExternal",
+            "enum": [
+              "external"
+            ]
           }
         ]
       },


### PR DESCRIPTION
Here is a brief summary of what I did:

- MultiBandGdalSource always reads data relative to Volume (or Upload) base path
- Data from DataConnects cannot always refer to Volumes, because the base paths may not be known or varying (e.g. CDN) or need more metadata (e.g. AWS_ENDPOINT)
- this PR introduce a new DataPath variant EXTERNAL where the tile files path is absolute and external (not refering the file system but rather a URL or gdal virtual file system)
