### PR TITLE
ci: enforce strict Clippy lints by denying warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Rustfmt
         run: just backend lint-rustfmt
       - name: Clippy
-        run: just backend lint-clippy
+        run: just backend lint-clippy --deny-warnings
       - name: SQLFluff
         run: just backend lint-sql
 

--- a/geoengine/justfile
+++ b/geoengine/justfile
@@ -21,10 +21,11 @@ generate-openapi-spec: common::_clear
 lint: common::_clear lint-rustfmt lint-clippy lint-sql
 
 # Run clippy for all features and all targets.
-[arg('fix', long='fix', value='--fix', help='Automatically apply fixes where possible.')]
+[arg('fix', long='fix', value='--fix --allow-dirty', help='Automatically apply fixes where possible.')]
+[arg('deny-warnings', long='deny-warnings', value='-D warnings', help='Deny warnings.')]
 [group("lint")]
-lint-clippy fix="": common::_clear
-    cargo clippy --all-features --all-targets {{ if fix == "--fix" { "--fix --allow-dirty" } else { "" } }}
+lint-clippy fix="" deny-warnings="": common::_clear
+    cargo clippy --all-features --all-targets {{ fix }} -- {{ deny-warnings }}
 
 # Run rustfmt
 [arg('write', long='write', value='--write', help='Write changes to files instead of checking.')]


### PR DESCRIPTION
Clippy's warnings were not detected by the CI, now they are.